### PR TITLE
Feature/sfat 247 multi public az nlb nat

### DIFF
--- a/ccs-scale-infra-network/terraform/environments/sbx2/main.tf
+++ b/ccs-scale-infra-network/terraform/environments/sbx2/main.tf
@@ -22,52 +22,33 @@ locals {
   environment    = "SBX2"
   cidr_block_vpc = "192.168.0.0/16"
 
+  # One AZ
   subnet_configs = {
     "public_web" = {
       "eu-west-2a" = {
         "az_id"      = "2a"
-        "cidr_block" = "192.168.31.0/24"
+        "cidr_block" = "192.168.1.0/24"
       }
-      "eu-west-2b" = {
-        "az_id"      = "2b"
-        "cidr_block" = "192.168.34.0/24"
-      }
-      "eu-west-2c" = {
-        "az_id"      = "2c"
-        "cidr_block" = "192.168.37.0/24"
-      }
+      # Additional AZ blocks (maps) go here. No comma separation required.
     }
     "private_app" = {
       "eu-west-2a" = {
         "az_id"      = "2a"
-        "cidr_block" = "192.168.32.0/24"
-      }
-      "eu-west-2b" = {
-        "az_id"      = "2b"
-        "cidr_block" = "192.168.35.0/24"
-      }
-      "eu-west-2c" = {
-        "az_id"      = "2c"
-        "cidr_block" = "192.168.38.0/24"
+        "cidr_block" = "192.168.3.0/24"
       }
     }
     "private_db" = {
       "eu-west-2a" = {
         "az_id"      = "2a"
-        "cidr_block" = "192.168.33.0/24"
+        "cidr_block" = "192.168.5.0/24"
       }
       "eu-west-2b" = {
         "az_id"      = "2b"
-        "cidr_block" = "192.168.36.0/24"
-      }
-      "eu-west-2c" = {
-        "az_id"      = "2c"
-        "cidr_block" = "192.168.39.0/24"
+        "cidr_block" = "192.168.11.0/24"
       }
     }
   }
 }
-
 
 data "aws_ssm_parameter" "aws_account_id" {
   name = "account-id-${lower(local.environment)}"
@@ -90,7 +71,7 @@ module "ssm" {
   private_app_subnet_ids = module.vpc.private_app_subnet_ids
   private_db_subnet_ids  = module.vpc.private_db_subnet_ids
   cidr_block_vpc         = local.cidr_block_vpc
-  cidr_blocks_web        = [local.subnet_configs["public_web"]["eu-west-2a"]["cidr_block"], local.subnet_configs["public_web"]["eu-west-2b"]["cidr_block"], local.subnet_configs["public_web"]["eu-west-2c"]["cidr_block"]]
-  cidr_blocks_app        = [local.subnet_configs["private_app"]["eu-west-2a"]["cidr_block"], local.subnet_configs["private_app"]["eu-west-2b"]["cidr_block"], local.subnet_configs["private_app"]["eu-west-2c"]["cidr_block"]]
-  cidr_blocks_db         = [local.subnet_configs["private_db"]["eu-west-2a"]["cidr_block"], local.subnet_configs["private_db"]["eu-west-2b"]["cidr_block"], local.subnet_configs["private_db"]["eu-west-2c"]["cidr_block"]]
+  cidr_blocks_web        = [local.subnet_configs["public_web"]["eu-west-2a"]["cidr_block"]]
+  cidr_blocks_app        = [local.subnet_configs["private_app"]["eu-west-2a"]["cidr_block"]]
+  cidr_blocks_db         = [local.subnet_configs["private_db"]["eu-west-2a"]["cidr_block"], local.subnet_configs["private_db"]["eu-west-2b"]["cidr_block"]]
 }

--- a/ccs-scale-infra-network/terraform/environments/sbx2/main.tf
+++ b/ccs-scale-infra-network/terraform/environments/sbx2/main.tf
@@ -22,33 +22,52 @@ locals {
   environment    = "SBX2"
   cidr_block_vpc = "192.168.0.0/16"
 
-  # One AZ
   subnet_configs = {
     "public_web" = {
       "eu-west-2a" = {
         "az_id"      = "2a"
-        "cidr_block" = "192.168.1.0/24"
+        "cidr_block" = "192.168.31.0/24"
       }
-      # Additional AZ blocks (maps) go here. No comma separation required.
+      "eu-west-2b" = {
+        "az_id"      = "2b"
+        "cidr_block" = "192.168.34.0/24"
+      }
+      "eu-west-2c" = {
+        "az_id"      = "2c"
+        "cidr_block" = "192.168.37.0/24"
+      }
     }
     "private_app" = {
       "eu-west-2a" = {
         "az_id"      = "2a"
-        "cidr_block" = "192.168.3.0/24"
+        "cidr_block" = "192.168.32.0/24"
+      }
+      "eu-west-2b" = {
+        "az_id"      = "2b"
+        "cidr_block" = "192.168.35.0/24"
+      }
+      "eu-west-2c" = {
+        "az_id"      = "2c"
+        "cidr_block" = "192.168.38.0/24"
       }
     }
     "private_db" = {
       "eu-west-2a" = {
         "az_id"      = "2a"
-        "cidr_block" = "192.168.5.0/24"
+        "cidr_block" = "192.168.33.0/24"
       }
       "eu-west-2b" = {
         "az_id"      = "2b"
-        "cidr_block" = "192.168.11.0/24"
+        "cidr_block" = "192.168.36.0/24"
+      }
+      "eu-west-2c" = {
+        "az_id"      = "2c"
+        "cidr_block" = "192.168.39.0/24"
       }
     }
   }
 }
+
 
 data "aws_ssm_parameter" "aws_account_id" {
   name = "account-id-${lower(local.environment)}"
@@ -71,7 +90,7 @@ module "ssm" {
   private_app_subnet_ids = module.vpc.private_app_subnet_ids
   private_db_subnet_ids  = module.vpc.private_db_subnet_ids
   cidr_block_vpc         = local.cidr_block_vpc
-  cidr_blocks_web        = [local.subnet_configs["public_web"]["eu-west-2a"]["cidr_block"]]
-  cidr_blocks_app        = [local.subnet_configs["private_app"]["eu-west-2a"]["cidr_block"]]
-  cidr_blocks_db         = [local.subnet_configs["private_db"]["eu-west-2a"]["cidr_block"], local.subnet_configs["private_db"]["eu-west-2b"]["cidr_block"]]
+  cidr_blocks_web        = [local.subnet_configs["public_web"]["eu-west-2a"]["cidr_block"], local.subnet_configs["public_web"]["eu-west-2b"]["cidr_block"], local.subnet_configs["public_web"]["eu-west-2c"]["cidr_block"]]
+  cidr_blocks_app        = [local.subnet_configs["private_app"]["eu-west-2a"]["cidr_block"], local.subnet_configs["private_app"]["eu-west-2b"]["cidr_block"], local.subnet_configs["private_app"]["eu-west-2c"]["cidr_block"]]
+  cidr_blocks_db         = [local.subnet_configs["private_db"]["eu-west-2a"]["cidr_block"], local.subnet_configs["private_db"]["eu-west-2b"]["cidr_block"], local.subnet_configs["private_db"]["eu-west-2c"]["cidr_block"]]
 }

--- a/ccs-scale-infra-shared/terraform/environments/dev/main.tf
+++ b/ccs-scale-infra-shared/terraform/environments/dev/main.tf
@@ -20,10 +20,6 @@ provider "aws" {
 
 locals {
   environment = "DEV"
-
-  # Elastic IPs, provisioned by ccs-scale-bootstrap
-  eip_id_nat = "eipalloc-0eccfa091115cf688"
-  eip_id_nlb = "eipalloc-05a9678206ee28099"
 }
 
 data "aws_ssm_parameter" "aws_account_id" {
@@ -34,6 +30,4 @@ module "deploy" {
   source         = "../../modules/configs/deploy-all"
   aws_account_id = data.aws_ssm_parameter.aws_account_id.value
   environment    = local.environment
-  eip_id_nat     = local.eip_id_nat
-  eip_id_nlb     = local.eip_id_nlb
 }

--- a/ccs-scale-infra-shared/terraform/environments/int/main.tf
+++ b/ccs-scale-infra-shared/terraform/environments/int/main.tf
@@ -20,10 +20,6 @@ provider "aws" {
 
 locals {
   environment = "INT"
-
-  # Elastic IPs, provisioned by ccs-scale-bootstrap
-  eip_id_nat = "eipalloc-002e35cc08c541a08"
-  eip_id_nlb = "eipalloc-07a206364ae965a99"
 }
 
 data "aws_ssm_parameter" "aws_account_id" {
@@ -34,6 +30,4 @@ module "deploy" {
   source         = "../../modules/configs/deploy-all"
   aws_account_id = data.aws_ssm_parameter.aws_account_id.value
   environment    = local.environment
-  eip_id_nat     = local.eip_id_nat
-  eip_id_nlb     = local.eip_id_nlb
 }

--- a/ccs-scale-infra-shared/terraform/environments/nft/main.tf
+++ b/ccs-scale-infra-shared/terraform/environments/nft/main.tf
@@ -20,10 +20,6 @@ provider "aws" {
 
 locals {
   environment = "NFT"
-
-  # Elastic IPs, provisioned by ccs-scale-bootstrap
-  eip_id_nat = "eipalloc-0ebc4100552ab138b"
-  eip_id_nlb = "eipalloc-0bc5b95b763f6bc6a"
 }
 
 data "aws_ssm_parameter" "aws_account_id" {
@@ -34,6 +30,4 @@ module "deploy" {
   source         = "../../modules/configs/deploy-all"
   aws_account_id = data.aws_ssm_parameter.aws_account_id.value
   environment    = local.environment
-  eip_id_nat     = local.eip_id_nat
-  eip_id_nlb     = local.eip_id_nlb
 }

--- a/ccs-scale-infra-shared/terraform/environments/sbx1/main.tf
+++ b/ccs-scale-infra-shared/terraform/environments/sbx1/main.tf
@@ -20,10 +20,6 @@ provider "aws" {
 
 locals {
   environment = "SBX1"
-
-  # Elastic IPs, provisioned by ccs-scale-bootstrap
-  eip_id_nat = "eipalloc-090ce84d6f36c3b55"
-  eip_id_nlb = "eipalloc-0643c7a763f04bb59"
 }
 
 data "aws_ssm_parameter" "aws_account_id" {
@@ -34,6 +30,4 @@ module "deploy" {
   source         = "../../modules/configs/deploy-all"
   aws_account_id = data.aws_ssm_parameter.aws_account_id.value
   environment    = local.environment
-  eip_id_nat     = local.eip_id_nat
-  eip_id_nlb     = local.eip_id_nlb
 }

--- a/ccs-scale-infra-shared/terraform/environments/sbx2/main.tf
+++ b/ccs-scale-infra-shared/terraform/environments/sbx2/main.tf
@@ -1,5 +1,5 @@
 #########################################################
-# Environment: SBX2 
+# Environment: SBX2
 #
 # Deploy SCALE resources
 #########################################################
@@ -20,10 +20,6 @@ provider "aws" {
 
 locals {
   environment = "SBX2"
-
-  # Elastic IPs, provisioned by ccs-scale-bootstrap
-  eip_id_nat = "eipalloc-0c9ebc279097d44e9"
-  eip_id_nlb = "eipalloc-0712849d1a74fc334"
 }
 
 data "aws_ssm_parameter" "aws_account_id" {
@@ -34,6 +30,4 @@ module "deploy" {
   source         = "../../modules/configs/deploy-all"
   aws_account_id = data.aws_ssm_parameter.aws_account_id.value
   environment    = local.environment
-  eip_id_nat     = local.eip_id_nat
-  eip_id_nlb     = local.eip_id_nlb
 }

--- a/ccs-scale-infra-shared/terraform/environments/sbx3/main.tf
+++ b/ccs-scale-infra-shared/terraform/environments/sbx3/main.tf
@@ -20,10 +20,6 @@ provider "aws" {
 
 locals {
   environment = "SBX3"
-
-  # Elastic IPs, provisioned by ccs-scale-bootstrap
-  eip_id_nat = ""
-  eip_id_nlb = ""
 }
 
 data "aws_ssm_parameter" "aws_account_id" {
@@ -34,6 +30,4 @@ module "deploy" {
   source         = "../../modules/configs/deploy-all"
   aws_account_id = data.aws_ssm_parameter.aws_account_id.value
   environment    = local.environment
-  eip_id_nat     = local.eip_id_nat
-  eip_id_nlb     = local.eip_id_nlb
 }

--- a/ccs-scale-infra-shared/terraform/environments/sbx4/main.tf
+++ b/ccs-scale-infra-shared/terraform/environments/sbx4/main.tf
@@ -1,5 +1,5 @@
 #########################################################
-# Environment: SBX4 
+# Environment: SBX4
 #
 # Deploy SCALE resources
 #########################################################
@@ -20,10 +20,6 @@ provider "aws" {
 
 locals {
   environment = "SBX4"
-
-  # Elastic IPs, provisioned by ccs-scale-bootstrap
-  eip_id_nat = ""
-  eip_id_nlb = ""
 }
 
 data "aws_ssm_parameter" "aws_account_id" {
@@ -34,6 +30,4 @@ module "deploy" {
   source         = "../../modules/configs/deploy-all"
   aws_account_id = data.aws_ssm_parameter.aws_account_id.value
   environment    = local.environment
-  eip_id_nat     = local.eip_id_nat
-  eip_id_nlb     = local.eip_id_nlb
 }

--- a/ccs-scale-infra-shared/terraform/environments/sbx5/main.tf
+++ b/ccs-scale-infra-shared/terraform/environments/sbx5/main.tf
@@ -20,10 +20,6 @@ provider "aws" {
 
 locals {
   environment = "SBX5"
-
-  # Elastic IPs, provisioned by ccs-scale-bootstrap
-  eip_id_nat = "eipalloc-05ab839ab38a4a621"
-  eip_id_nlb = "eipalloc-041536928f0d13bfe"
 }
 
 data "aws_ssm_parameter" "aws_account_id" {
@@ -34,6 +30,4 @@ module "deploy" {
   source         = "../../modules/configs/deploy-all"
   aws_account_id = data.aws_ssm_parameter.aws_account_id.value
   environment    = local.environment
-  eip_id_nat     = local.eip_id_nat
-  eip_id_nlb     = local.eip_id_nlb
 }

--- a/ccs-scale-infra-shared/terraform/environments/sbx6/main.tf
+++ b/ccs-scale-infra-shared/terraform/environments/sbx6/main.tf
@@ -20,10 +20,6 @@ provider "aws" {
 
 locals {
   environment = "SBX6"
-
-  # Elastic IPs, provisioned by ccs-scale-bootstrap
-  eip_id_nat = ""
-  eip_id_nlb = ""
 }
 
 data "aws_ssm_parameter" "aws_account_id" {
@@ -34,6 +30,4 @@ module "deploy" {
   source         = "../../modules/configs/deploy-all"
   aws_account_id = data.aws_ssm_parameter.aws_account_id.value
   environment    = local.environment
-  eip_id_nat     = local.eip_id_nat
-  eip_id_nlb     = local.eip_id_nlb
 }

--- a/ccs-scale-infra-shared/terraform/environments/sbx7/main.tf
+++ b/ccs-scale-infra-shared/terraform/environments/sbx7/main.tf
@@ -20,10 +20,6 @@ provider "aws" {
 
 locals {
   environment = "SBX7"
-
-  # Elastic IPs, provisioned by ccs-scale-bootstrap
-  eip_id_nat = ""
-  eip_id_nlb = ""
 }
 
 data "aws_ssm_parameter" "aws_account_id" {
@@ -34,6 +30,4 @@ module "deploy" {
   source         = "../../modules/configs/deploy-all"
   aws_account_id = data.aws_ssm_parameter.aws_account_id.value
   environment    = local.environment
-  eip_id_nat     = local.eip_id_nat
-  eip_id_nlb     = local.eip_id_nlb
 }

--- a/ccs-scale-infra-shared/terraform/environments/tst/main.tf
+++ b/ccs-scale-infra-shared/terraform/environments/tst/main.tf
@@ -20,10 +20,6 @@ provider "aws" {
 
 locals {
   environment = "TST"
-
-  # Elastic IPs, provisioned by ccs-scale-bootstrap
-  eip_id_nat = "eipalloc-058c4a8af0cc0883d"
-  eip_id_nlb = "eipalloc-00ea3efb96a3e0231"
 }
 
 data "aws_ssm_parameter" "aws_account_id" {
@@ -34,6 +30,4 @@ module "deploy" {
   source         = "../../modules/configs/deploy-all"
   aws_account_id = data.aws_ssm_parameter.aws_account_id.value
   environment    = local.environment
-  eip_id_nat     = local.eip_id_nat
-  eip_id_nlb     = local.eip_id_nlb
 }

--- a/ccs-scale-infra-shared/terraform/modules/configs/deploy-all/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/configs/deploy-all/main.tf
@@ -53,8 +53,6 @@ module "infrastructure" {
   public_web_subnet_ids  = split(",", data.aws_ssm_parameter.public_web_subnet_ids.value)
   private_db_subnet_ids  = split(",", data.aws_ssm_parameter.private_db_subnet_ids.value)
   ecr_access_cidr_blocks = flatten([split(",", data.aws_ssm_parameter.cidr_blocks_web.value), split(",", data.aws_ssm_parameter.cidr_blocks_app.value), split(",", data.aws_ssm_parameter.cidr_blocks_db.value)])
-  eip_id_nat             = var.eip_id_nat
-  eip_id_nlb             = var.eip_id_nlb
 }
 
 module "ssm" {

--- a/ccs-scale-infra-shared/terraform/modules/configs/deploy-all/variables.tf
+++ b/ccs-scale-infra-shared/terraform/modules/configs/deploy-all/variables.tf
@@ -5,11 +5,3 @@ variable "aws_account_id" {
 variable "environment" {
   type = string
 }
-
-variable "eip_id_nat" {
-  type = string
-}
-
-variable "eip_id_nlb" {
-  type = string
-}

--- a/ccs-scale-infra-shared/terraform/modules/infrastructure/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/infrastructure/main.tf
@@ -7,6 +7,15 @@ provider "aws" {
   }
 }
 
+
+data "aws_ssm_parameter" "nat_eip_ids" {
+  name = "${lower(var.environment)}-eip-ids-nat-gateway"
+}
+
+data "aws_ssm_parameter" "public_nlb_eip_ids" {
+  name = "${lower(var.environment)}-eip-ids-public-nlb"
+}
+
 module "network" {
   source                 = "./network"
   environment            = var.environment
@@ -15,8 +24,8 @@ module "network" {
   public_web_subnet_ids  = var.public_web_subnet_ids
   private_db_subnet_ids  = var.private_db_subnet_ids
   ecr_access_cidr_blocks = var.ecr_access_cidr_blocks
-  eip_id_nat             = var.eip_id_nat
-  eip_id_nlb             = var.eip_id_nlb
+  nat_eip_ids            = split(",", data.aws_ssm_parameter.nat_eip_ids.value)
+  public_nlb_eip_ids     = split(",", data.aws_ssm_parameter.public_nlb_eip_ids.value)
 }
 
 module "cloudfront" {

--- a/ccs-scale-infra-shared/terraform/modules/infrastructure/network/load-balancer.tf
+++ b/ccs-scale-infra-shared/terraform/modules/infrastructure/network/load-balancer.tf
@@ -46,10 +46,13 @@ resource "aws_lb" "public" {
   load_balancer_type = "network"
   depends_on         = [aws_internet_gateway.scale]
 
-  subnet_mapping {
-    # TODO: Iterate on subnet IDs (must be hardcoded values)
-    subnet_id     = var.public_web_subnet_ids[0]
-    allocation_id = var.eip_id_nlb
+  dynamic "subnet_mapping" {
+    for_each = var.public_web_subnet_ids
+
+    content {
+      subnet_id     = subnet_mapping.value
+      allocation_id = var.public_nlb_eip_ids[subnet_mapping.key] # key=index
+    }
   }
 
   tags = {

--- a/ccs-scale-infra-shared/terraform/modules/infrastructure/network/variables.tf
+++ b/ccs-scale-infra-shared/terraform/modules/infrastructure/network/variables.tf
@@ -30,10 +30,10 @@ variable "ecr_access_cidr_blocks" {
   type = list(string)
 }
 
-variable "eip_id_nat" {
-  type = string
+variable "nat_eip_ids" {
+  type = list
 }
 
-variable "eip_id_nlb" {
-  type = string
+variable "public_nlb_eip_ids" {
+  type = list
 }

--- a/ccs-scale-infra-shared/terraform/modules/infrastructure/network/vpc.tf
+++ b/ccs-scale-infra-shared/terraform/modules/infrastructure/network/vpc.tf
@@ -224,7 +224,6 @@ resource "aws_internet_gateway" "scale" {
 
 ##############################################################
 # NAT Gateway for private subnets outbound traffic
-# Availability Zone A only at the moment (no redundancy)
 ##############################################################
 
 # Provide a datasource to obtain the subnet's AZ ID for NAT naming

--- a/ccs-scale-infra-shared/terraform/modules/infrastructure/variables.tf
+++ b/ccs-scale-infra-shared/terraform/modules/infrastructure/variables.tf
@@ -30,11 +30,3 @@ variable "private_db_subnet_ids" {
 variable "ecr_access_cidr_blocks" {
   type = list(string)
 }
-
-variable "eip_id_nat" {
-  type = string
-}
-
-variable "eip_id_nlb" {
-  type = string
-}


### PR DESCRIPTION
Ignore the change in the SBX2 main - I'll revert it tomorrow.  This all seems to work on SBX2 (currently mimicking NFT).  Have requested SBX2 EIPs be whitelisted so I can verify all three NAT Gateways working as expected.  Buyer UI is definitely accessible via either Cloudfront or the direct NLB node EIPs, so hopefully it's all correct!

There is one more coming to expand the buyer UI ECS count..