### PR TITLE
Extend bastion host SG ingress/egress to cover n4j port

### DIFF
--- a/ccs-scale-infra-shared/terraform/modules/bastion/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/bastion/main.tf
@@ -19,6 +19,7 @@ resource "aws_security_group" "allow_bastion_db_access" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+
   ingress {
     from_port   = 5432
     to_port     = 5432
@@ -26,9 +27,23 @@ resource "aws_security_group" "allow_bastion_db_access" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  ingress {
+    from_port   = 7687
+    to_port     = 7687
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
   egress {
     from_port   = 5432
     to_port     = 5432
+    protocol    = "tcp"
+    cidr_blocks = var.db_cidr_blocks
+  }
+
+  egress {
+    from_port   = 7687
+    to_port     = 7687
     protocol    = "tcp"
     cidr_blocks = var.db_cidr_blocks
   }


### PR DESCRIPTION
Applied and tested this on SBX2, configured the tunnel via:

```
$ ssh -i ~/.ssh/sbx2-bastion-key.pem -L 7687:SCALE-EU2-SBX2-NLB-INTERNAL-DB-55981b6e1cb05530.elb.eu-west-2.amazonaws.com:7687 ubuntu@ec2-3-9-172-74.eu-west-2.compute.amazonaws.com
```

..then connected from Neo4J browser to `bolt://localhost:7687` using the service credentials - voila!