### PR TITLE
Feature/sfat 238 cloudtrail 

### DIFF
--- a/ccs-scale-infra-shared/terraform/environments/nft/main.tf
+++ b/ccs-scale-infra-shared/terraform/environments/nft/main.tf
@@ -31,3 +31,9 @@ module "deploy" {
   aws_account_id = data.aws_ssm_parameter.aws_account_id.value
   environment    = local.environment
 }
+
+module "cloudtrail" {
+  source         = "../../modules/cloudtrail"
+  aws_account_id = data.aws_ssm_parameter.aws_account_id.value
+  environment    = local.environment
+}

--- a/ccs-scale-infra-shared/terraform/environments/nft/main.tf
+++ b/ccs-scale-infra-shared/terraform/environments/nft/main.tf
@@ -27,13 +27,10 @@ data "aws_ssm_parameter" "aws_account_id" {
 }
 
 module "deploy" {
-  source         = "../../modules/configs/deploy-all"
-  aws_account_id = data.aws_ssm_parameter.aws_account_id.value
-  environment    = local.environment
-}
-
-module "cloudtrail" {
-  source         = "../../modules/cloudtrail"
-  aws_account_id = data.aws_ssm_parameter.aws_account_id.value
-  environment    = local.environment
+  source                              = "../../modules/configs/deploy-all"
+  aws_account_id                      = data.aws_ssm_parameter.aws_account_id.value
+  environment                         = local.environment
+  cloudtrail_cw_log_retention_in_days = 30
+  cloudtrail_s3_log_retention_in_days = 30
+  cloudwatch_s3_force_destroy         = false
 }

--- a/ccs-scale-infra-shared/terraform/environments/sbx1/main.tf
+++ b/ccs-scale-infra-shared/terraform/environments/sbx1/main.tf
@@ -31,3 +31,9 @@ module "deploy" {
   aws_account_id = data.aws_ssm_parameter.aws_account_id.value
   environment    = local.environment
 }
+
+module "cloudtrail" {
+  source         = "../../modules/cloudtrail"
+  aws_account_id = data.aws_ssm_parameter.aws_account_id.value
+  environment    = local.environment
+}

--- a/ccs-scale-infra-shared/terraform/environments/sbx1/main.tf
+++ b/ccs-scale-infra-shared/terraform/environments/sbx1/main.tf
@@ -31,9 +31,3 @@ module "deploy" {
   aws_account_id = data.aws_ssm_parameter.aws_account_id.value
   environment    = local.environment
 }
-
-module "cloudtrail" {
-  source         = "../../modules/cloudtrail"
-  aws_account_id = data.aws_ssm_parameter.aws_account_id.value
-  environment    = local.environment
-}

--- a/ccs-scale-infra-shared/terraform/modules/cloudtrail/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/cloudtrail/main.tf
@@ -1,0 +1,174 @@
+#########################################################
+# CloudTrail
+#
+# Cloud Trail and CloudWatch Alarms
+#########################################################
+provider "aws" {
+  profile = "default"
+  region  = "eu-west-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${var.aws_account_id}:role/CCS_SCALE_Build"
+  }
+}
+
+locals {
+  s3_bucket_name = "scale-${lower(var.environment)}-s3-cloudtrail-logs"
+}
+
+module "globals" {
+  source = "../globals"
+}
+
+##########################
+# CloudTrail log bucket
+##########################
+resource "aws_s3_bucket" "cloudtrail" {
+  bucket        = local.s3_bucket_name
+  force_destroy = true
+
+  policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AWSCloudTrailAclCheck",
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "cloudtrail.amazonaws.com"
+            },
+            "Action": "s3:GetBucketAcl",
+            "Resource": "arn:aws:s3:::${local.s3_bucket_name}"
+        },
+        {
+            "Sid": "AWSCloudTrailWrite",
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "cloudtrail.amazonaws.com"
+            },
+            "Action": "s3:PutObject",
+            "Resource": "arn:aws:s3:::${local.s3_bucket_name}/*",
+            "Condition": {
+                "StringEquals": {
+                    "s3:x-amz-acl": "bucket-owner-full-control"
+                }
+            }
+        }
+    ]
+}
+POLICY
+}
+
+##########################
+# CloudWatch Log Group
+##########################
+resource "aws_cloudwatch_log_group" "cloudtrail" {
+  name              = "/cloudtrail/${lower(var.environment)}"
+  retention_in_days = 30
+
+  tags = {
+    Project     = module.globals.project_name
+    Environment = upper(var.environment)
+    Cost_Code   = module.globals.project_cost_code
+    AppType     = "CLOUDTRAIL"
+  }
+}
+
+resource "aws_iam_role" "cloudtrail" {
+  name               = "CCS_SCALE_CloudTrail"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "cloudtrail.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+
+  tags = {
+    Project     = module.globals.project_name
+    Environment = upper(var.environment)
+    Cost_Code   = module.globals.project_cost_code
+    AppType     = "CLOUDTRAIL"
+  }
+}
+
+resource "aws_iam_policy" "cloudtrail" {
+  name        = "CCS_SCALE_CloudTrail"
+  path        = "/"
+  description = "CCS SCALE cloudtrail policy (provisioned by Terraform)"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "logs:*"
+        ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "cloudtrail" {
+  role       = aws_iam_role.cloudtrail.name
+  policy_arn = aws_iam_policy.cloudtrail.arn
+}
+
+##########################
+# CloudTrail
+##########################
+resource "aws_cloudtrail" "scale" {
+  name                          = "CCS-EU2-${upper(var.environment)}-CLOUDTRAIL"
+  s3_bucket_name                = aws_s3_bucket.cloudtrail.id
+  include_global_service_events = true
+  enable_log_file_validation    = true
+  cloud_watch_logs_group_arn    = aws_cloudwatch_log_group.cloudtrail.arn
+  cloud_watch_logs_role_arn     = aws_iam_role.cloudtrail.arn
+}
+
+##############################
+# SNS Topic: CloudTrail Alarms
+##############################
+resource "aws_sns_topic" "cloudtrail_alarms" {
+  name = "CCS-EU2-${upper(var.environment)}-CLOUDTRAIL-ALARMS"
+}
+
+###########################
+# Alarm: S3 Bucket Activity
+###########################
+resource "aws_cloudwatch_log_metric_filter" "s3" {
+  name           = "S3BucketActivity"
+  pattern        = "{ ($.eventSource = s3.amazonaws.com) && (($.eventName = PutBucketAcl) || ($.eventName = PutBucketPolicy) || ($.eventName = PutBucketCors) || ($.eventName = PutBucketLifecycle) || ($.eventName = PutBucketReplication) || ($.eventName = DeleteBucketPolicy) || ($.eventName = DeleteBucketCors) || ($.eventName = DeleteBucketLifecycle) || ($.eventName = DeleteBucketReplication)) }"
+  log_group_name = aws_cloudwatch_log_group.cloudtrail.name
+
+  metric_transformation {
+    name      = "S3BucketActivityEventCount"
+    namespace = "CloudTrailMetrics"
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "s3" {
+  alarm_name                = "S3BucketActivity"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = "S3BucketActivityEventCount"
+  namespace                 = "CloudTrailMetrics"
+  period                    = "300"
+  statistic                 = "Sum"
+  threshold                 = "1"
+  alarm_description         = "This metric monitors S3 bucket activity"
+  insufficient_data_actions = []
+  alarm_actions             = [aws_sns_topic.cloudtrail_alarms.arn]
+}

--- a/ccs-scale-infra-shared/terraform/modules/cloudtrail/variables.tf
+++ b/ccs-scale-infra-shared/terraform/modules/cloudtrail/variables.tf
@@ -1,0 +1,7 @@
+variable "aws_account_id" {
+  type = string
+}
+
+variable "environment" {
+  type = string
+}

--- a/ccs-scale-infra-shared/terraform/modules/cloudtrail/variables.tf
+++ b/ccs-scale-infra-shared/terraform/modules/cloudtrail/variables.tf
@@ -5,3 +5,15 @@ variable "aws_account_id" {
 variable "environment" {
   type = string
 }
+
+variable "cloudtrail_cw_log_retention_in_days" {
+  type = number
+}
+
+variable "cloudtrail_s3_log_retention_in_days" {
+  type = number
+}
+
+variable "cloudwatch_s3_force_destroy" {
+  type = bool
+}

--- a/ccs-scale-infra-shared/terraform/modules/configs/deploy-all/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/configs/deploy-all/main.tf
@@ -73,3 +73,12 @@ module "bastion" {
   subnet_id      = split(",", data.aws_ssm_parameter.public_web_subnet_ids.value)[0]
   db_cidr_blocks = split(",", data.aws_ssm_parameter.cidr_blocks_db.value)
 }
+
+module "cloudtrail" {
+  source                              = "../../cloudtrail"
+  aws_account_id                      = var.aws_account_id
+  environment                         = var.environment
+  cloudtrail_cw_log_retention_in_days = var.cloudtrail_cw_log_retention_in_days
+  cloudtrail_s3_log_retention_in_days = var.cloudtrail_s3_log_retention_in_days
+  cloudwatch_s3_force_destroy         = var.cloudwatch_s3_force_destroy
+}

--- a/ccs-scale-infra-shared/terraform/modules/configs/deploy-all/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/configs/deploy-all/main.tf
@@ -74,6 +74,10 @@ module "bastion" {
   db_cidr_blocks = split(",", data.aws_ssm_parameter.cidr_blocks_db.value)
 }
 
+# CloudTrail is not really required in lower enviromnments.
+# We should be able to turn this off easily using the module 'count=0' property when 
+# it becomes available in Terraform 0.13 if required
+# https://www.hashicorp.com/blog/announcing-the-terraform-0-13-beta/
 module "cloudtrail" {
   source                              = "../../cloudtrail"
   aws_account_id                      = var.aws_account_id

--- a/ccs-scale-infra-shared/terraform/modules/configs/deploy-all/variables.tf
+++ b/ccs-scale-infra-shared/terraform/modules/configs/deploy-all/variables.tf
@@ -5,3 +5,18 @@ variable "aws_account_id" {
 variable "environment" {
   type = string
 }
+
+variable "cloudtrail_cw_log_retention_in_days" {
+  type    = number
+  default = 1
+}
+
+variable "cloudtrail_s3_log_retention_in_days" {
+  type    = number
+  default = 1
+}
+
+variable "cloudwatch_s3_force_destroy" {
+  type    = bool
+  default = true
+}

--- a/ccs-scale-infra-shared/terraform/modules/ssm/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/ssm/main.tf
@@ -8,40 +8,34 @@ resource "aws_ssm_parameter" "lb_private_arn" {
   name  = "${lower(var.environment)}-lb-private-arn"
   type  = "String"
   value = var.lb_private_arn
-  overwrite = true
 }
 
 resource "aws_ssm_parameter" "lb_private_db_arn" {
   name  = "${lower(var.environment)}-lb-private-db-arn"
   type  = "String"
   value = var.lb_private_db_arn
-  overwrite = true
 }
 
 resource "aws_ssm_parameter" "lb_public_arn" {
   name  = "${lower(var.environment)}-lb-public-arn"
   type  = "String"
   value = var.lb_public_arn
-  overwrite = true
 }
 
 resource "aws_ssm_parameter" "vpc_link_id" {
   name  = "${lower(var.environment)}-vpc-link-id"
   type  = "String"
   value = var.vpc_link_id
-  overwrite = true
 }
 
 resource "aws_ssm_parameter" "lb_private_dns" {
   name  = "${lower(var.environment)}-lb-private-dns"
   type  = "String"
   value = var.lb_private_dns
-  overwrite = true
 }
 
 resource "aws_ssm_parameter" "lb_private_db_dns" {
   name  = "${lower(var.environment)}-lb-private-db-dns"
   type  = "String"
   value = var.lb_private_db_dns
-  overwrite = true
 }

--- a/ccs-scale-infra-shared/terraform/modules/ssm/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/ssm/main.tf
@@ -8,34 +8,40 @@ resource "aws_ssm_parameter" "lb_private_arn" {
   name  = "${lower(var.environment)}-lb-private-arn"
   type  = "String"
   value = var.lb_private_arn
+  overwrite = true
 }
 
 resource "aws_ssm_parameter" "lb_private_db_arn" {
   name  = "${lower(var.environment)}-lb-private-db-arn"
   type  = "String"
   value = var.lb_private_db_arn
+  overwrite = true
 }
 
 resource "aws_ssm_parameter" "lb_public_arn" {
   name  = "${lower(var.environment)}-lb-public-arn"
   type  = "String"
   value = var.lb_public_arn
+  overwrite = true
 }
 
 resource "aws_ssm_parameter" "vpc_link_id" {
   name  = "${lower(var.environment)}-vpc-link-id"
   type  = "String"
   value = var.vpc_link_id
+  overwrite = true
 }
 
 resource "aws_ssm_parameter" "lb_private_dns" {
   name  = "${lower(var.environment)}-lb-private-dns"
   type  = "String"
   value = var.lb_private_dns
+  overwrite = true
 }
 
 resource "aws_ssm_parameter" "lb_private_db_dns" {
   name  = "${lower(var.environment)}-lb-private-db-dns"
   type  = "String"
   value = var.lb_private_db_dns
+  overwrite = true
 }


### PR DESCRIPTION
This is an initial commit candidate for SFAT-238 (but not the whole thing). 

This will create an account specific CloudTrail trail, log them in S3 and push the events to CloudWatch.

I have implemented one alarm - based on S3 activity. There is also an SNS topic (which TechOps can use with OpsGenie). I have tested this by subscribing my email and receive an alert if I drop a file into an S3 bucket.

I thought this might be enough for a tick in the box if it is part of any NFT testing next week.

There is a list of alerts in the JIRA ticket - intention would be to follow up and implement the rest of them (have asked John Denford if they have any examples of Terraform - as they are suggesting these alerts, and that they be terraformed - no reply yet).

Please - any suggestions for improvements/changes gratefully received! 😄 