### PR TITLE
WIP tighten NACLs as prerequisite to CF-NLB restriction

### DIFF
--- a/ccs-scale-infra-network/terraform/modules/vpc/main.tf
+++ b/ccs-scale-infra-network/terraform/modules/vpc/main.tf
@@ -35,15 +35,23 @@ resource "aws_vpc" "SCALE-Services" {
   }
 }
 
+# This special resource instructs TF to 'adopt' the default NACL and strip it
+# of its permissive default ruleset
+resource "aws_default_network_acl" "default" {
+  default_network_acl_id = aws_vpc.SCALE-Services.default_network_acl_id
+
+  # no rules defined, deny all traffic in this ACL
+}
+
 ##############################################################
 # Public Subnets
 ##############################################################
 resource "aws_subnet" "SCALE-AZ-WEB-Public" {
   for_each = var.subnet_configs["public_web"]
 
-  vpc_id            = aws_vpc.SCALE-Services.id
-  cidr_block        = each.value["cidr_block"]
-  availability_zone = each.key
+  vpc_id                  = aws_vpc.SCALE-Services.id
+  cidr_block              = each.value["cidr_block"]
+  availability_zone       = each.key
   map_public_ip_on_launch = true
 
   tags = {

--- a/ccs-scale-infra-shared/terraform/modules/bastion/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/bastion/main.tf
@@ -19,7 +19,6 @@ resource "aws_security_group" "allow_bastion_db_access" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-
   ingress {
     from_port   = 5432
     to_port     = 5432
@@ -46,6 +45,21 @@ resource "aws_security_group" "allow_bastion_db_access" {
     to_port     = 7687
     protocol    = "tcp"
     cidr_blocks = var.db_cidr_blocks
+  }
+
+  # For OS updates etc
+  egress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
   }
 }
 

--- a/ccs-scale-infra-shared/terraform/modules/configs/deploy-all/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/configs/deploy-all/main.tf
@@ -52,7 +52,6 @@ module "infrastructure" {
   private_app_subnet_ids = split(",", data.aws_ssm_parameter.private_app_subnet_ids.value)
   public_web_subnet_ids  = split(",", data.aws_ssm_parameter.public_web_subnet_ids.value)
   private_db_subnet_ids  = split(",", data.aws_ssm_parameter.private_db_subnet_ids.value)
-  ecr_access_cidr_blocks = flatten([split(",", data.aws_ssm_parameter.cidr_blocks_web.value), split(",", data.aws_ssm_parameter.cidr_blocks_app.value), split(",", data.aws_ssm_parameter.cidr_blocks_db.value)])
 }
 
 module "ssm" {
@@ -75,7 +74,7 @@ module "bastion" {
 }
 
 # CloudTrail is not really required in lower enviromnments.
-# We should be able to turn this off easily using the module 'count=0' property when 
+# We should be able to turn this off easily using the module 'count=0' property when
 # it becomes available in Terraform 0.13 if required
 # https://www.hashicorp.com/blog/announcing-the-terraform-0-13-beta/
 module "cloudtrail" {

--- a/ccs-scale-infra-shared/terraform/modules/infrastructure/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/infrastructure/main.tf
@@ -23,7 +23,6 @@ module "network" {
   private_app_subnet_ids = var.private_app_subnet_ids
   public_web_subnet_ids  = var.public_web_subnet_ids
   private_db_subnet_ids  = var.private_db_subnet_ids
-  ecr_access_cidr_blocks = var.ecr_access_cidr_blocks
   nat_eip_ids            = split(",", data.aws_ssm_parameter.nat_eip_ids.value)
   public_nlb_eip_ids     = split(",", data.aws_ssm_parameter.public_nlb_eip_ids.value)
 }

--- a/ccs-scale-infra-shared/terraform/modules/infrastructure/network/variables.tf
+++ b/ccs-scale-infra-shared/terraform/modules/infrastructure/network/variables.tf
@@ -26,10 +26,6 @@ variable "private_db_subnet_ids" {
   type = list(string)
 }
 
-variable "ecr_access_cidr_blocks" {
-  type = list(string)
-}
-
 variable "nat_eip_ids" {
   type = list
 }

--- a/ccs-scale-infra-shared/terraform/modules/infrastructure/network/vpc.tf
+++ b/ccs-scale-infra-shared/terraform/modules/infrastructure/network/vpc.tf
@@ -184,6 +184,16 @@ resource "aws_network_acl" "scale_external" {
     to_port    = 443
   }
 
+  # Allow outbound traffic to the internet on port 443
+  egress {
+    protocol   = "tcp"
+    rule_no    = 90
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 80
+    to_port    = 80
+  }
+
   tags = {
     Name        = "SCALE:EU2:${upper(var.environment)}:VPC:ACL-EXTERNAL"
     Project     = module.globals.project_name

--- a/ccs-scale-infra-shared/terraform/modules/infrastructure/network/vpc.tf
+++ b/ccs-scale-infra-shared/terraform/modules/infrastructure/network/vpc.tf
@@ -11,6 +11,10 @@ module "globals" {
   source = "../../globals"
 }
 
+data "aws_vpc" "scale" {
+  id = var.vpc_id
+}
+
 resource "aws_vpc_endpoint" "vpc_endpoint_ecr" {
   vpc_id            = var.vpc_id
   service_name      = "com.amazonaws.eu-west-2.ecr.dkr"
@@ -79,7 +83,7 @@ resource "aws_security_group" "allow_inbound_https" {
     from_port   = 443
     to_port     = 443
     protocol    = "tcp"
-    cidr_blocks = var.ecr_access_cidr_blocks
+    cidr_blocks = tolist([data.aws_vpc.scale.cidr_block])
   }
 
   tags = {
@@ -91,15 +95,191 @@ resource "aws_security_group" "allow_inbound_https" {
 }
 
 ##############################################################
-# VPC Access control list
+# VPC Access control lists - one for each subnet group (public, private, database)
 ##############################################################
 
-resource "aws_network_acl" "scale" {
+resource "aws_network_acl" "scale_external" {
+  vpc_id     = var.vpc_id
+  subnet_ids = var.public_web_subnet_ids
+
+  # Allow all inbound traffic on the external load balancer listener port
+  # TODO: Remove as part of SSL lockdown
+  ingress {
+    protocol   = "tcp"
+    rule_no    = 10
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = var.http_port
+    to_port    = var.http_port
+  }
+
+  # Allow inbound traffic to NAT from instances within the VPC
+  ingress {
+    protocol   = "tcp"
+    rule_no    = 20
+    action     = "allow"
+    cidr_block = data.aws_vpc.scale.cidr_block
+    from_port  = var.https_port
+    to_port    = var.https_port
+  }
+
+  # Allow all inbound traffic on the NAT G/W ephemeral ports
+  ingress {
+    protocol   = "tcp"
+    rule_no    = 30
+    action     = "allow"
+    cidr_block = "0.0.0.0/0" # CCS range?
+    from_port  = 1024
+    to_port    = 65535
+  }
+
+  # Allow all inbound traffic on the SSH port (Bastion host)
+  ingress {
+    protocol   = "tcp"
+    rule_no    = 40
+    action     = "allow"
+    cidr_block = "0.0.0.0/0" # CCS range?
+    from_port  = 22
+    to_port    = 22
+  }
+
+  # Allow outbound traffic to the VPC on port 443
+  egress {
+    protocol   = "tcp"
+    rule_no    = 50
+    action     = "allow"
+    cidr_block = data.aws_vpc.scale.cidr_block
+    from_port  = var.http_port
+    to_port    = var.http_port
+  }
+
+  # Allow outbound traffic to the VPC on instance/health check ports
+  # Buyer UI only
+  egress {
+    protocol   = "tcp"
+    rule_no    = 60
+    action     = "allow"
+    cidr_block = data.aws_vpc.scale.cidr_block
+    from_port  = 9030
+    to_port    = 9030
+  }
+
+  # Allow all outbound traffic on the ephemeral ports (for responses)
+  egress {
+    protocol   = "tcp"
+    rule_no    = 70
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 1024
+    to_port    = 65535
+  }
+
+  # Allow all outbound traffic on port 443 (from Buyer UI via NAT Gateway to CCS)
+  egress {
+    protocol   = "tcp"
+    rule_no    = 90
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 443
+    to_port    = 443
+  }
+
+  tags = {
+    Name        = "SCALE:EU2:${upper(var.environment)}:VPC:ACL-EXTERNAL"
+    Project     = module.globals.project_name
+    Environment = upper(var.environment)
+    Cost_Code   = module.globals.project_cost_code
+    AppType     = "NETWORK"
+  }
+}
+
+resource "aws_network_acl" "scale_internal" {
   vpc_id     = var.vpc_id
   subnet_ids = var.private_app_subnet_ids
 
+  # Allow inbound traffic from the VPC on the instance+health check ports
+  # Decision Tree Service
+  ingress {
+    protocol   = "tcp"
+    rule_no    = 20
+    action     = "allow"
+    cidr_block = data.aws_vpc.scale.cidr_block
+    from_port  = 9000
+    to_port    = 9000
+  }
+
+  # Agreements Service
+  ingress {
+    protocol   = "tcp"
+    rule_no    = 30
+    action     = "allow"
+    cidr_block = data.aws_vpc.scale.cidr_block
+    from_port  = 9010
+    to_port    = 9010
+  }
+
+  # Guided Match Service
+  ingress {
+    protocol   = "tcp"
+    rule_no    = 40
+    action     = "allow"
+    cidr_block = data.aws_vpc.scale.cidr_block
+    from_port  = 9020
+    to_port    = 9020
+  }
+
+  # Buyer UI
+  ingress {
+    protocol   = "tcp"
+    rule_no    = 50
+    action     = "allow"
+    cidr_block = data.aws_vpc.scale.cidr_block
+    from_port  = 9030
+    to_port    = 9030
+  }
+
+  #Allow inbound traffic from the VPC on port 443 for VPC Link / other AWS services
+  ingress {
+    protocol   = "tcp"
+    rule_no    = 61
+    action     = "allow"
+    cidr_block = data.aws_vpc.scale.cidr_block
+    from_port  = var.https_port
+    to_port    = var.https_port
+  }
+
+  # Allow inbound internet traffic on the ephemeral ports (for responses)
+  ingress {
+    protocol   = "tcp"
+    rule_no    = 70
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 1024
+    to_port    = 65535
+  }
+
+  # Allow outbound VPC traffic on the ephemeral ports for responses to internal services
+  egress {
+    protocol   = "tcp"
+    rule_no    = 80
+    action     = "allow"
+    cidr_block = data.aws_vpc.scale.cidr_block
+    from_port  = 1024
+    to_port    = 65535
+  }
+
+  # Allow outbound internet traffic on port 443 (Buyer UI -> NAT / ECR)
+  egress {
+    protocol   = "tcp"
+    rule_no    = 90
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 443
+    to_port    = 443
+  }
+
   tags = {
-    Name        = "SCALE:EU2:${upper(var.environment)}:VPC:ACL"
+    Name        = "SCALE:EU2:${upper(var.environment)}:VPC:ACL-INTERNAL"
     Project     = module.globals.project_name
     Environment = upper(var.environment)
     Cost_Code   = module.globals.project_cost_code
@@ -107,103 +287,78 @@ resource "aws_network_acl" "scale" {
   }
 }
 
-resource "aws_network_acl_rule" "ingress_http" {
-  network_acl_id = aws_network_acl.scale.id
-  egress         = false
-  from_port      = 80
-  to_port        = 80
-  rule_number    = 100
-  rule_action    = "allow"
-  protocol       = "tcp"
-  cidr_block     = "0.0.0.0/0"
-}
+resource "aws_network_acl" "scale_database" {
+  vpc_id     = var.vpc_id
+  subnet_ids = var.private_db_subnet_ids
 
-resource "aws_network_acl_rule" "ingress_https" {
-  network_acl_id = aws_network_acl.scale.id
-  egress         = false
-  from_port      = 443
-  to_port        = 443
-  rule_number    = 110
-  rule_action    = "allow"
-  protocol       = "tcp"
-  cidr_block     = "0.0.0.0/0"
-}
+  # Allow traffic from the VPC to database ports
+  # Postgres
+  ingress {
+    protocol   = "tcp"
+    rule_no    = 10
+    action     = "allow"
+    cidr_block = data.aws_vpc.scale.cidr_block
+    from_port  = 5432
+    to_port    = 5432
+  }
 
-resource "aws_network_acl_rule" "ingress_http_9000" {
-  network_acl_id = aws_network_acl.scale.id
-  egress         = false
-  from_port      = 9000
-  to_port        = 9000
-  rule_number    = 130
-  rule_action    = "allow"
-  protocol       = "tcp"
-  cidr_block     = "0.0.0.0/0"
-}
+  # Neo4J
+  ingress {
+    protocol   = "tcp"
+    rule_no    = 20
+    action     = "allow"
+    cidr_block = data.aws_vpc.scale.cidr_block
+    from_port  = 7687
+    to_port    = 7687
+  }
 
-resource "aws_network_acl_rule" "ingress_http_9010" {
-  network_acl_id = aws_network_acl.scale.id
-  egress         = false
-  from_port      = 9010
-  to_port        = 9010
-  rule_number    = 140
-  rule_action    = "allow"
-  protocol       = "tcp"
-  cidr_block     = "0.0.0.0/0"
-}
+  # Inbound from ECR / other AWS services
+  ingress {
+    protocol   = "tcp"
+    rule_no    = 61
+    action     = "allow"
+    cidr_block = data.aws_vpc.scale.cidr_block
+    from_port  = var.https_port
+    to_port    = var.https_port
+  }
 
-resource "aws_network_acl_rule" "ingress_http_9030" {
-  network_acl_id = aws_network_acl.scale.id
-  egress         = false
-  from_port      = 9030
-  to_port        = 9030
-  rule_number    = 150
-  rule_action    = "allow"
-  protocol       = "tcp"
-  cidr_block     = "0.0.0.0/0"
-}
+  # Allow inbound traffic from VPC on ephemeral ports for responses from internal / external services
+  ingress {
+    protocol   = "tcp"
+    rule_no    = 70
+    action     = "allow"
+    cidr_block = data.aws_vpc.scale.cidr_block
+    from_port  = 1024
+    to_port    = 65535
+  }
 
-resource "aws_network_acl_rule" "egress_http" {
-  network_acl_id = aws_network_acl.scale.id
-  egress         = true
-  from_port      = var.http_port
-  to_port        = var.http_port
-  rule_number    = 160
-  rule_action    = "allow"
-  protocol       = "tcp"
-  cidr_block     = "0.0.0.0/0"
-}
+  # Allow outbound trafficto the VPC on port 443 (ECR)
+  egress {
+    protocol   = "tcp"
+    rule_no    = 90
+    action     = "allow"
+    cidr_block = data.aws_vpc.scale.cidr_block
+    from_port  = 443
+    to_port    = 443
+  }
 
-resource "aws_network_acl_rule" "egress_https" {
-  network_acl_id = aws_network_acl.scale.id
-  egress         = true
-  from_port      = var.https_port
-  to_port        = var.https_port
-  rule_number    = 170
-  rule_action    = "allow"
-  protocol       = "tcp"
-  cidr_block     = "0.0.0.0/0"
-}
+  # Allow outbound traffic to the VPC on the ephemeral ports for responses to internal services
+  egress {
+    protocol   = "tcp"
+    rule_no    = 30
+    action     = "allow"
+    cidr_block = data.aws_vpc.scale.cidr_block
+    from_port  = 1024
+    to_port    = 65535
+  }
 
-resource "aws_network_acl_rule" "ingress_ephemeral" {
-  network_acl_id = aws_network_acl.scale.id
-  egress         = false
-  from_port      = 1024
-  to_port        = 65535
-  rule_number    = 200
-  rule_action    = "allow"
-  protocol       = "tcp"
-  cidr_block     = "0.0.0.0/0"
-}
-
-resource "aws_network_acl_rule" "egress_ephemeral" {
-  network_acl_id = aws_network_acl.scale.id
-  egress         = true
-  from_port      = 1024
-  to_port        = 65535
-  rule_number    = 210
-  rule_action    = "allow"
-  protocol       = "tcp"
-  cidr_block     = "0.0.0.0/0"
+  tags = {
+    Name        = "SCALE:EU2:${upper(var.environment)}:VPC:ACL-DB"
+    Project     = module.globals.project_name
+    Environment = upper(var.environment)
+    Cost_Code   = module.globals.project_cost_code
+    AppType     = "NETWORK"
+  }
 }
 
 ##############################################################

--- a/ccs-scale-infra-shared/terraform/modules/infrastructure/network/vpc.tf
+++ b/ccs-scale-infra-shared/terraform/modules/infrastructure/network/vpc.tf
@@ -177,7 +177,7 @@ resource "aws_network_acl" "scale_external" {
   # Allow all outbound traffic on port 443 (from Buyer UI via NAT Gateway to CCS)
   egress {
     protocol   = "tcp"
-    rule_no    = 90
+    rule_no    = 80
     action     = "allow"
     cidr_block = "0.0.0.0/0"
     from_port  = 443
@@ -201,7 +201,7 @@ resource "aws_network_acl" "scale_internal" {
   # Decision Tree Service
   ingress {
     protocol   = "tcp"
-    rule_no    = 20
+    rule_no    = 10
     action     = "allow"
     cidr_block = data.aws_vpc.scale.cidr_block
     from_port  = 9000
@@ -211,7 +211,7 @@ resource "aws_network_acl" "scale_internal" {
   # Agreements Service
   ingress {
     protocol   = "tcp"
-    rule_no    = 30
+    rule_no    = 20
     action     = "allow"
     cidr_block = data.aws_vpc.scale.cidr_block
     from_port  = 9010
@@ -221,7 +221,7 @@ resource "aws_network_acl" "scale_internal" {
   # Guided Match Service
   ingress {
     protocol   = "tcp"
-    rule_no    = 40
+    rule_no    = 30
     action     = "allow"
     cidr_block = data.aws_vpc.scale.cidr_block
     from_port  = 9020
@@ -231,7 +231,7 @@ resource "aws_network_acl" "scale_internal" {
   # Buyer UI
   ingress {
     protocol   = "tcp"
-    rule_no    = 50
+    rule_no    = 40
     action     = "allow"
     cidr_block = data.aws_vpc.scale.cidr_block
     from_port  = 9030
@@ -241,7 +241,7 @@ resource "aws_network_acl" "scale_internal" {
   #Allow inbound traffic from the VPC on port 443 for VPC Link / other AWS services
   ingress {
     protocol   = "tcp"
-    rule_no    = 61
+    rule_no    = 50
     action     = "allow"
     cidr_block = data.aws_vpc.scale.cidr_block
     from_port  = var.https_port
@@ -251,7 +251,7 @@ resource "aws_network_acl" "scale_internal" {
   # Allow inbound internet traffic on the ephemeral ports (for responses)
   ingress {
     protocol   = "tcp"
-    rule_no    = 70
+    rule_no    = 60
     action     = "allow"
     cidr_block = "0.0.0.0/0"
     from_port  = 1024
@@ -261,7 +261,7 @@ resource "aws_network_acl" "scale_internal" {
   # Allow outbound VPC traffic on the ephemeral ports for responses to internal services
   egress {
     protocol   = "tcp"
-    rule_no    = 80
+    rule_no    = 70
     action     = "allow"
     cidr_block = data.aws_vpc.scale.cidr_block
     from_port  = 1024
@@ -271,7 +271,7 @@ resource "aws_network_acl" "scale_internal" {
   # Allow outbound internet traffic on port 443 (Buyer UI -> NAT / ECR)
   egress {
     protocol   = "tcp"
-    rule_no    = 90
+    rule_no    = 80
     action     = "allow"
     cidr_block = "0.0.0.0/0"
     from_port  = 443
@@ -315,7 +315,7 @@ resource "aws_network_acl" "scale_database" {
   # Inbound from ECR / other AWS services
   ingress {
     protocol   = "tcp"
-    rule_no    = 61
+    rule_no    = 30
     action     = "allow"
     cidr_block = data.aws_vpc.scale.cidr_block
     from_port  = var.https_port
@@ -325,19 +325,39 @@ resource "aws_network_acl" "scale_database" {
   # Allow inbound traffic from VPC on ephemeral ports for responses from internal / external services
   ingress {
     protocol   = "tcp"
-    rule_no    = 70
+    rule_no    = 40
     action     = "allow"
     cidr_block = data.aws_vpc.scale.cidr_block
     from_port  = 1024
     to_port    = 65535
   }
 
-  # Allow outbound trafficto the VPC on port 443 (ECR)
+  # Allow inbound internet traffic on the ephemeral ports (for responses)
+  ingress {
+    protocol   = "tcp"
+    rule_no    = 50
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 1024
+    to_port    = 65535
+  }
+
+  # Allow outbound traffic to the VPC on port 443 (ECR)
   egress {
     protocol   = "tcp"
-    rule_no    = 90
+    rule_no    = 60
     action     = "allow"
     cidr_block = data.aws_vpc.scale.cidr_block
+    from_port  = 443
+    to_port    = 443
+  }
+
+  # Allow outbound internet traffic on port 443 (ECR)
+  egress {
+    protocol   = "tcp"
+    rule_no    = 70
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
     from_port  = 443
     to_port    = 443
   }
@@ -345,7 +365,7 @@ resource "aws_network_acl" "scale_database" {
   # Allow outbound traffic to the VPC on the ephemeral ports for responses to internal services
   egress {
     protocol   = "tcp"
-    rule_no    = 30
+    rule_no    = 80
     action     = "allow"
     cidr_block = data.aws_vpc.scale.cidr_block
     from_port  = 1024

--- a/ccs-scale-infra-shared/terraform/modules/infrastructure/variables.tf
+++ b/ccs-scale-infra-shared/terraform/modules/infrastructure/variables.tf
@@ -26,7 +26,3 @@ variable "public_web_subnet_ids" {
 variable "private_db_subnet_ids" {
   type = list(string)
 }
-
-variable "ecr_access_cidr_blocks" {
-  type = list(string)
-}


### PR DESCRIPTION
Lock down the default NACL that permits **all** inbound/outbound traffic for unassigned subnets, and create a NACL with inline ingress/egress rules tailored to each subnet group.

This also contributes to SFAT-281 (tighten sec groups + NACLs).  Tested an ECS update on each service to ensure the connection via VPC Link to ECR is still working (that took a bit of fiddling around), and all Buyer UI traffic + bastion host / DB access is working on SBX2 as far as I can tell - be good to test on different env though.