### PR TITLE
Enforce HTTPS only to Cloudfront

### DIFF
--- a/ccs-scale-infra-shared/terraform/modules/infrastructure/cloudfront/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/infrastructure/cloudfront/main.tf
@@ -70,7 +70,7 @@ resource "aws_cloudfront_distribution" "fat_buyer_ui_distribution" {
       }
     }
 
-    viewer_protocol_policy = "allow-all"
+    viewer_protocol_policy = "https-only"
     min_ttl                = 0
     default_ttl            = 3600
     max_ttl                = 86400


### PR DESCRIPTION
Might have overestimated this one slightly... 😄 
Question - do we think this should be as-is `https-only` or `redirect-to-https`?  My feeling is that as it's really only supposed to be accessed by us / testers / reverse proxy (and may be firewalled in higher envs to only accept traffic from the CCS proxy) so it should be `https-only`..