### PR TITLE
Restrict bastion host access

### DIFF
--- a/ccs-scale-infra-shared/terraform/modules/bastion/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/bastion/main.tf
@@ -16,23 +16,10 @@ resource "aws_security_group" "allow_bastion_db_access" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = var.cidr_blocks_allowed_external
   }
 
-  ingress {
-    from_port   = 5432
-    to_port     = 5432
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  ingress {
-    from_port   = 7687
-    to_port     = 7687
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
+  # For connection to Postgres and Neo4j
   egress {
     from_port   = 5432
     to_port     = 5432

--- a/ccs-scale-infra-shared/terraform/modules/bastion/variables.tf
+++ b/ccs-scale-infra-shared/terraform/modules/bastion/variables.tf
@@ -17,3 +17,7 @@ variable "db_cidr_blocks" {
 variable "bastion_kms_key_id" {
   type = string
 }
+
+variable "cidr_blocks_allowed_external" {
+  type = list
+}

--- a/ccs-scale-infra-shared/terraform/modules/configs/deploy-all/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/configs/deploy-all/main.tf
@@ -49,6 +49,10 @@ data "aws_ssm_parameter" "bastion_kms_key_id" {
   name = "${lower(var.environment)}-bastion-encryption-key"
 }
 
+data "aws_ssm_parameter" "cidr_blocks_allowed_external" {
+  name = "${lower(var.environment)}-cidr-blocks-external-allowed"
+}
+
 module "infrastructure" {
   source                              = "../../infrastructure"
   aws_account_id                      = var.aws_account_id
@@ -73,12 +77,13 @@ module "ssm" {
 }
 
 module "bastion" {
-  source             = "../../bastion"
-  environment        = var.environment
-  vpc_id             = data.aws_ssm_parameter.vpc_id.value
-  subnet_id          = split(",", data.aws_ssm_parameter.public_web_subnet_ids.value)[0]
-  db_cidr_blocks     = split(",", data.aws_ssm_parameter.cidr_blocks_db.value)
-  bastion_kms_key_id = data.aws_ssm_parameter.bastion_kms_key_id.value
+  source                       = "../../bastion"
+  environment                  = var.environment
+  vpc_id                       = data.aws_ssm_parameter.vpc_id.value
+  subnet_id                    = split(",", data.aws_ssm_parameter.public_web_subnet_ids.value)[0]
+  db_cidr_blocks               = split(",", data.aws_ssm_parameter.cidr_blocks_db.value)
+  bastion_kms_key_id           = data.aws_ssm_parameter.bastion_kms_key_id.value
+  cidr_blocks_allowed_external = split(",", data.aws_ssm_parameter.cidr_blocks_allowed_external.value)
 }
 
 # CloudTrail is not really required in lower enviromnments.


### PR DESCRIPTION
Part 2 of 2 - pick up the environment specific allowed CIDR ranges and apply them to the bastion host port 22 ingress rule.