### PR TITLE
SINF-135 - enabled ec2 instance connect on bastion host

### DIFF
--- a/ccs-scale-infra-shared/terraform/modules/bastion/init.sh
+++ b/ccs-scale-infra-shared/terraform/modules/bastion/init.sh
@@ -1,0 +1,8 @@
+#! /bin/bash
+#
+
+set -e -x
+
+sudo apt-get update
+sudo apt-get upgrade -y
+sudo apt-get install ec2-instance-connect

--- a/ccs-scale-infra-shared/terraform/modules/bastion/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/bastion/main.tf
@@ -63,6 +63,10 @@ resource "aws_security_group" "allow_bastion_db_access" {
   }
 }
 
+data "template_file" "init" {
+  template = file("${path.module}/init.sh")
+}
+
 resource "aws_instance" "bastion_host" {
   ami                         = "ami-0be057a22c63962cb"
   instance_type               = "t2.micro"
@@ -70,6 +74,7 @@ resource "aws_instance" "bastion_host" {
   subnet_id                   = var.subnet_id
   vpc_security_group_ids      = [aws_security_group.allow_bastion_db_access.id]
   associate_public_ip_address = true
+  user_data                   = data.template_file.init.rendered
 
   root_block_device {
     encrypted  = true


### PR DESCRIPTION
This will install Instance Connect on the FaT bastion hosts - so we can use that approach to connect instead of the root key if we choose to (I will email details).

This is not an immediate requirement, not directly BaT related. Wasn't sure which branch to merge to - thought 'develop', with a view that it's there if we wanted to update the Bastion in any environment at any point..