### PR TITLE
Spark and Cognizant CIDR ranges for bastion host external access

### DIFF
--- a/ccs-scale-infra-shared/terraform/modules/configs/deploy-all/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/configs/deploy-all/main.tf
@@ -61,6 +61,13 @@ data "aws_ssm_parameter" "cidr_blocks_allowed_external_cognizant" {
   name = "${lower(var.environment)}-cidr-blocks-allowed-external-cognizant"
 }
 
+locals {
+  # Normalised CIDR blocks (accounting for 'none' i.e. "-" as value in SSM parameter)
+  cidr_blocks_allowed_external_ccs       = data.aws_ssm_parameter.cidr_blocks_allowed_external_ccs.value != "-" ? split(",", data.aws_ssm_parameter.cidr_blocks_allowed_external_ccs.value) : []
+  cidr_blocks_allowed_external_spark     = data.aws_ssm_parameter.cidr_blocks_allowed_external_spark.value != "-" ? split(",", data.aws_ssm_parameter.cidr_blocks_allowed_external_spark.value) : []
+  cidr_blocks_allowed_external_cognizant = data.aws_ssm_parameter.cidr_blocks_allowed_external_cognizant.value != "-" ? split(",", data.aws_ssm_parameter.cidr_blocks_allowed_external_cognizant.value) : []
+}
+
 module "infrastructure" {
   source                              = "../../infrastructure"
   aws_account_id                      = var.aws_account_id
@@ -91,7 +98,7 @@ module "bastion" {
   subnet_id                    = split(",", data.aws_ssm_parameter.public_web_subnet_ids.value)[0]
   db_cidr_blocks               = split(",", data.aws_ssm_parameter.cidr_blocks_db.value)
   bastion_kms_key_id           = data.aws_ssm_parameter.bastion_kms_key_id.value
-  cidr_blocks_allowed_external = concat(split(",", data.aws_ssm_parameter.cidr_blocks_allowed_external_ccs.value), split(",", data.aws_ssm_parameter.cidr_blocks_allowed_external_spark.value), split(",", data.aws_ssm_parameter.cidr_blocks_allowed_external_cognizant.value))
+  cidr_blocks_allowed_external = concat(local.cidr_blocks_allowed_external_ccs, local.cidr_blocks_allowed_external_spark, local.cidr_blocks_allowed_external_cognizant)
 }
 
 # CloudTrail is not really required in lower enviromnments.

--- a/ccs-scale-infra-shared/terraform/modules/configs/deploy-all/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/configs/deploy-all/main.tf
@@ -57,6 +57,10 @@ data "aws_ssm_parameter" "cidr_blocks_allowed_external_spark" {
   name = "${lower(var.environment)}-cidr-blocks-allowed-external-spark"
 }
 
+data "aws_ssm_parameter" "cidr_blocks_allowed_external_cognizant" {
+  name = "${lower(var.environment)}-cidr-blocks-allowed-external-cognizant"
+}
+
 module "infrastructure" {
   source                              = "../../infrastructure"
   aws_account_id                      = var.aws_account_id
@@ -87,7 +91,7 @@ module "bastion" {
   subnet_id                    = split(",", data.aws_ssm_parameter.public_web_subnet_ids.value)[0]
   db_cidr_blocks               = split(",", data.aws_ssm_parameter.cidr_blocks_db.value)
   bastion_kms_key_id           = data.aws_ssm_parameter.bastion_kms_key_id.value
-  cidr_blocks_allowed_external = concat(split(",", data.aws_ssm_parameter.cidr_blocks_allowed_external_ccs.value), split(",", data.aws_ssm_parameter.cidr_blocks_allowed_external_spark.value))
+  cidr_blocks_allowed_external = concat(split(",", data.aws_ssm_parameter.cidr_blocks_allowed_external_ccs.value), split(",", data.aws_ssm_parameter.cidr_blocks_allowed_external_spark.value), split(",", data.aws_ssm_parameter.cidr_blocks_allowed_external_cognizant.value))
 }
 
 # CloudTrail is not really required in lower enviromnments.

--- a/ccs-scale-infra-shared/terraform/modules/configs/deploy-all/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/configs/deploy-all/main.tf
@@ -49,8 +49,12 @@ data "aws_ssm_parameter" "bastion_kms_key_id" {
   name = "${lower(var.environment)}-bastion-encryption-key"
 }
 
-data "aws_ssm_parameter" "cidr_blocks_allowed_external" {
-  name = "${lower(var.environment)}-cidr-blocks-external-allowed"
+data "aws_ssm_parameter" "cidr_blocks_allowed_external_ccs" {
+  name = "${lower(var.environment)}-cidr-blocks-allowed-external-ccs"
+}
+
+data "aws_ssm_parameter" "cidr_blocks_allowed_external_spark" {
+  name = "${lower(var.environment)}-cidr-blocks-allowed-external-spark"
 }
 
 module "infrastructure" {
@@ -83,7 +87,7 @@ module "bastion" {
   subnet_id                    = split(",", data.aws_ssm_parameter.public_web_subnet_ids.value)[0]
   db_cidr_blocks               = split(",", data.aws_ssm_parameter.cidr_blocks_db.value)
   bastion_kms_key_id           = data.aws_ssm_parameter.bastion_kms_key_id.value
-  cidr_blocks_allowed_external = split(",", data.aws_ssm_parameter.cidr_blocks_allowed_external.value)
+  cidr_blocks_allowed_external = concat(split(",", data.aws_ssm_parameter.cidr_blocks_allowed_external_ccs.value), split(",", data.aws_ssm_parameter.cidr_blocks_allowed_external_spark.value))
 }
 
 # CloudTrail is not really required in lower enviromnments.


### PR DESCRIPTION
Wasn't sure if this should be to develop or bat/develop - opted for latter but.. not sure.  The locals block pre-processes the SSM params to handle the 'null' value - `-` see https://github.com/Crown-Commercial-Service/ccs-scale-bootstrap/pull/69.  If there's a cleaner way to handle that I'm happy to rethink.