### PR TITLE
Add security headers via edge lambda / cloudfront

### DIFF
--- a/ccs-scale-infra-shared/terraform/modules/infrastructure/cloudfront/functions/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/infrastructure/cloudfront/functions/main.tf
@@ -1,0 +1,52 @@
+#########################################################
+# CloudFront Lambda@edge function resources
+#
+# 1) Add Security Headers
+#########################################################
+
+# Aliased provider for us-east-1 region for use by specific resources (e.g. ACM certificates)
+provider "aws" {
+  alias  = "lambda_edge"
+  region = var.lambda_edge_region
+  assume_role {
+    role_arn = "arn:aws:iam::${var.aws_account_id}:role/CCS_SCALE_Build"
+  }
+}
+
+resource "aws_iam_role" "lambda_edge_exec" {
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": ["lambda.amazonaws.com", "edgelambda.amazonaws.com"]
+      },
+      "Effect": "Allow"
+    }
+  ]
+}
+EOF
+}
+
+data "archive_file" "lambda_security_headers_zip" {
+  type        = "zip"
+  source_dir  = "${path.module}/security-headers"
+  output_path = "${path.module}/.build/security-headers.zip"
+}
+
+resource "aws_lambda_function" "security_headers" {
+  # Provision in Lambda@edge region (us-east-1)
+  provider = aws.lambda_edge
+
+  filename         = "${path.module}/.build/security-headers.zip"
+  source_code_hash = data.archive_file.lambda_security_headers_zip.output_base64sha256
+  function_name    = "security-headers"
+  role             = aws_iam_role.lambda_edge_exec.arn
+  description      = "Add HTTP security headers to responses"
+  handler          = "index.handler"
+  runtime          = "nodejs12.x"
+  timeout          = 10
+  publish          = true
+}

--- a/ccs-scale-infra-shared/terraform/modules/infrastructure/cloudfront/functions/outputs.tf
+++ b/ccs-scale-infra-shared/terraform/modules/infrastructure/cloudfront/functions/outputs.tf
@@ -1,0 +1,3 @@
+output "add_security_headers_function_qarn" {
+  value = aws_lambda_function.security_headers.qualified_arn
+}

--- a/ccs-scale-infra-shared/terraform/modules/infrastructure/cloudfront/functions/security-headers/index.js
+++ b/ccs-scale-infra-shared/terraform/modules/infrastructure/cloudfront/functions/security-headers/index.js
@@ -1,0 +1,36 @@
+'use strict';
+exports.handler = (event, context, callback) => {
+
+  //Get contents of response
+  const response = event.Records[0].cf.response;
+  const headers = response.headers;
+
+  //Set new headers
+  headers['strict-transport-security'] = [{
+    key: 'Strict-Transport-Security',
+    value: 'max-age=63072000; includeSubdomains; preload'
+  }];
+  headers['content-security-policy'] = [{
+    key: 'Content-Security-Policy',
+    value: "default-src 'none'; img-src 'self'; script-src 'self'; style-src 'self'; object-src 'none'"
+  }];
+  headers['x-content-type-options'] = [{
+    key: 'X-Content-Type-Options',
+    value: 'nosniff'
+  }];
+  headers['x-frame-options'] = [{
+    key: 'X-Frame-Options',
+    value: 'DENY'
+  }];
+  headers['x-xss-protection'] = [{
+    key: 'X-XSS-Protection',
+    value: '1; mode=block'
+  }];
+  headers['referrer-policy'] = [{
+    key: 'Referrer-Policy',
+    value: 'same-origin'
+  }];
+
+  //Return modified response
+  callback(null, response);
+};

--- a/ccs-scale-infra-shared/terraform/modules/infrastructure/cloudfront/functions/security-headers/index.js
+++ b/ccs-scale-infra-shared/terraform/modules/infrastructure/cloudfront/functions/security-headers/index.js
@@ -12,7 +12,7 @@ exports.handler = (event, context, callback) => {
   }];
   headers['content-security-policy'] = [{
     key: 'Content-Security-Policy',
-    value: "default-src 'none'; img-src 'self'; script-src 'self'; style-src 'self'; object-src 'none'"
+    value: "default-src 'none'; img-src 'self'; script-src 'self' 'unsafe-inline'; font-src fonts.gstatic.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com; object-src 'none'"
   }];
   headers['x-content-type-options'] = [{
     key: 'X-Content-Type-Options',

--- a/ccs-scale-infra-shared/terraform/modules/infrastructure/cloudfront/functions/variables.tf
+++ b/ccs-scale-infra-shared/terraform/modules/infrastructure/cloudfront/functions/variables.tf
@@ -1,0 +1,8 @@
+variable "aws_account_id" {
+  type = string
+}
+
+variable "lambda_edge_region" {
+  type    = string
+  default = "us-east-1"
+}


### PR DESCRIPTION
Will update on proposed approach to removing the additional directives in `content-security-policy` on the call at 10:30 😎 