### PR TITLE
Add XSS match set and rule to Cloudfront distro

### DIFF
--- a/ccs-scale-infra-shared/terraform/modules/infrastructure/cloudfront/waf.tf
+++ b/ccs-scale-infra-shared/terraform/modules/infrastructure/cloudfront/waf.tf
@@ -11,12 +11,57 @@ resource "aws_waf_rate_based_rule" "rate_limiting_rule" {
   rate_limit = 1000
 }
 
+#########################################################
+# XSS protection
+#########################################################
+resource "aws_waf_xss_match_set" "xss" {
+  name = "xss_match_set"
+
+  xss_match_tuples {
+    text_transformation = "URL_DECODE"
+
+    field_to_match {
+      type = "URI"
+    }
+  }
+
+  xss_match_tuples {
+    text_transformation = "URL_DECODE"
+
+    field_to_match {
+      type = "QUERY_STRING"
+    }
+  }
+
+  xss_match_tuples {
+    text_transformation = "HTML_ENTITY_DECODE"
+
+    field_to_match {
+      type = "BODY"
+    }
+  }
+}
+
+
+resource "aws_waf_rule" "xss" {
+  depends_on  = [aws_waf_xss_match_set.xss]
+  name        = "xssWAFRule"
+  metric_name = "xssWAFRule"
+
+  predicates {
+    data_id = aws_waf_xss_match_set.xss.id
+    negated = false
+    type    = "XssMatch"
+  }
+}
+
 resource "aws_waf_web_acl" "buyer_ui" {
   name        = "SCALE-EU2-${upper(var.environment)}-EXT-FatBuyerUI"
   metric_name = "wafBuyerUi"
 
   depends_on = [
     aws_waf_rate_based_rule.rate_limiting_rule,
+    aws_waf_rule.xss
   ]
 
   default_action {
@@ -31,5 +76,15 @@ resource "aws_waf_web_acl" "buyer_ui" {
     priority = 1
     rule_id  = aws_waf_rate_based_rule.rate_limiting_rule.id
     type     = "RATE_BASED"
+  }
+
+  rules {
+    action {
+      type = "BLOCK"
+    }
+
+    priority = 2
+    rule_id  = aws_waf_rule.xss.id
+    type     = "REGULAR"
   }
 }


### PR DESCRIPTION
Deployed to SBX2 - seems to be doing the trick:

```
GET https://sbx2.scale.crowncommercial.gov.uk/find-a-commercial-agreement/landing-page?q=linen&s=%3Cscript%3Ealert(%27boom%27)%3C/script%3E (BLOCK)
GET https://sbx2.scale.crowncommercial.gov.uk/find-a-commercial-agreement/blah%3Cscript%3Ealert(%27boom%27)%3C/script%3Eblah/landing-page?q=linen (BLOCK)
GET https://sbx2.scale.crowncommercial.gov.uk/find-a-commercial-agreement/landing-page?q=linen (ALLOW)
```
POSTing data containing XSS in the body is also blocked (tested via Postman).