### PR TITLE
SINF-256 - increased SBX8 (Ref environment) to 3 AZs

### DIFF
--- a/ccs-scale-infra-network/terraform/environments/sbx8/main.tf
+++ b/ccs-scale-infra-network/terraform/environments/sbx8/main.tf
@@ -22,7 +22,6 @@ locals {
   environment    = "SBX8"
   cidr_block_vpc = "192.168.0.0/16"
 
-  # One AZ
   subnet_configs = {
     "public_web" = {
       "eu-west-2a" = {
@@ -33,12 +32,23 @@ locals {
         "az_id"      = "2b"
         "cidr_block" = "192.168.5.0/24"
       }
-      # Additional AZ blocks (maps) go here. No comma separation required.
+      "eu-west-2c" = {
+        "az_id"      = "2c"
+        "cidr_block" = "192.168.9.0/24"
+      }
     }
     "private_app" = {
       "eu-west-2a" = {
         "az_id"      = "2a"
         "cidr_block" = "192.168.2.0/24"
+      }
+      "eu-west-2b" = {
+        "az_id"      = "2b"
+        "cidr_block" = "192.168.6.0/24"
+      }
+      "eu-west-2c" = {
+        "az_id"      = "2c"
+        "cidr_block" = "192.168.10.0/24"
       }
     }
     "private_db" = {
@@ -49,6 +59,10 @@ locals {
       "eu-west-2b" = {
         "az_id"      = "2b"
         "cidr_block" = "192.168.7.0/24"
+      }
+      "eu-west-2c" = {
+        "az_id"      = "2c"
+        "cidr_block" = "192.168.11.0/24"
       }
     }
   }
@@ -75,7 +89,7 @@ module "ssm" {
   private_app_subnet_ids = module.vpc.private_app_subnet_ids
   private_db_subnet_ids  = module.vpc.private_db_subnet_ids
   cidr_block_vpc         = local.cidr_block_vpc
-  cidr_blocks_web        = [local.subnet_configs["public_web"]["eu-west-2a"]["cidr_block"]]
-  cidr_blocks_app        = [local.subnet_configs["private_app"]["eu-west-2a"]["cidr_block"]]
-  cidr_blocks_db         = [local.subnet_configs["private_db"]["eu-west-2a"]["cidr_block"], local.subnet_configs["private_db"]["eu-west-2b"]["cidr_block"]]
+  cidr_blocks_web        = [local.subnet_configs["public_web"]["eu-west-2a"]["cidr_block"],local.subnet_configs["public_web"]["eu-west-2b"]["cidr_block"],local.subnet_configs["public_web"]["eu-west-2c"]["cidr_block"]]
+  cidr_blocks_app        = [local.subnet_configs["private_app"]["eu-west-2a"]["cidr_block"],local.subnet_configs["private_app"]["eu-west-2b"]["cidr_block"],local.subnet_configs["private_app"]["eu-west-2c"]["cidr_block"]]
+  cidr_blocks_db         = [local.subnet_configs["private_db"]["eu-west-2a"]["cidr_block"], local.subnet_configs["private_db"]["eu-west-2b"]["cidr_block"],local.subnet_configs["private_db"]["eu-west-2c"]["cidr_block"]]
 }


### PR DESCRIPTION
Increased the num of AZs in the Ref environment to 3 in prep for the resizing.

The existing SBX8 was following the CIDR block conventions for DEV as specified in the HLD. As DEV does not have ranges specified for 3 AZs - just followed the existing convention. For some reason `192.168.4.0/24` was skipped already. I think this was an oversight so just followed sequentially starting at `192.168.6.0/24`. Should probably get this approved by Som - may hold off applying this in that case (and get the rest of the changes lined up)

https://crowncommercialservice.atlassian.net/wiki/spaces/SCALE/pages/196837377/HLD+-+B.01+FaT+-+Infrastructure+Design#3.3-VPC-and-Subnets