### PR TITLE
SINF-256 - added extra APP AZ to DEV & INT (2AZs)

### DIFF
--- a/ccs-scale-infra-network/terraform/environments/dev/main.tf
+++ b/ccs-scale-infra-network/terraform/environments/dev/main.tf
@@ -22,7 +22,6 @@ locals {
   environment    = "DEV"
   cidr_block_vpc = "192.168.0.0/16"
 
-  # One AZ
   subnet_configs = {
     "public_web" = {
       "eu-west-2a" = {
@@ -33,12 +32,15 @@ locals {
         "az_id"      = "2b"
         "cidr_block" = "192.168.4.0/24"
       }
-      # Additional AZ blocks (maps) go here. No comma separation required.
     }
     "private_app" = {
       "eu-west-2a" = {
         "az_id"      = "2a"
         "cidr_block" = "192.168.3.0/24"
+      }
+      "eu-west-2b" = {
+        "az_id"      = "2b"
+        "cidr_block" = "192.168.9.0/24"
       }
     }
     "private_db" = {
@@ -75,8 +77,8 @@ module "ssm" {
   private_app_subnet_ids = module.vpc.private_app_subnet_ids
   private_db_subnet_ids  = module.vpc.private_db_subnet_ids
   cidr_block_vpc         = local.cidr_block_vpc
-  cidr_blocks_web        = [local.subnet_configs["public_web"]["eu-west-2a"]["cidr_block"]]
-  cidr_blocks_app        = [local.subnet_configs["private_app"]["eu-west-2a"]["cidr_block"]]
+  cidr_blocks_web        = [local.subnet_configs["public_web"]["eu-west-2a"]["cidr_block"], local.subnet_configs["public_web"]["eu-west-2b"]["cidr_block"]]
+  cidr_blocks_app        = [local.subnet_configs["private_app"]["eu-west-2a"]["cidr_block"], local.subnet_configs["private_app"]["eu-west-2b"]["cidr_block"]]
   cidr_blocks_db         = [local.subnet_configs["private_db"]["eu-west-2a"]["cidr_block"], local.subnet_configs["private_db"]["eu-west-2b"]["cidr_block"]]
 
 }

--- a/ccs-scale-infra-network/terraform/environments/int/main.tf
+++ b/ccs-scale-infra-network/terraform/environments/int/main.tf
@@ -22,7 +22,6 @@ locals {
   environment    = "INT"
   cidr_block_vpc = "192.168.0.0/16"
 
-  # One AZ
   subnet_configs = {
     "public_web" = {
       "eu-west-2a" = {
@@ -33,12 +32,15 @@ locals {
         "az_id"      = "2b"
         "cidr_block" = "192.168.14.0/24"
       }
-      # Additional AZ blocks (maps) go here. No comma separation required.
     }
     "private_app" = {
       "eu-west-2a" = {
         "az_id"      = "2a"
         "cidr_block" = "192.168.12.0/24"
+      }
+      "eu-west-2b" = {
+        "az_id"      = "2b"
+        "cidr_block" = "192.168.15.0/24"
       }
     }
     "private_db" = {
@@ -75,7 +77,7 @@ module "ssm" {
   private_app_subnet_ids = module.vpc.private_app_subnet_ids
   private_db_subnet_ids  = module.vpc.private_db_subnet_ids
   cidr_block_vpc         = local.cidr_block_vpc
-  cidr_blocks_web        = [local.subnet_configs["public_web"]["eu-west-2a"]["cidr_block"]]
-  cidr_blocks_app        = [local.subnet_configs["private_app"]["eu-west-2a"]["cidr_block"]]
+  cidr_blocks_web        = [local.subnet_configs["public_web"]["eu-west-2a"]["cidr_block"], local.subnet_configs["public_web"]["eu-west-2b"]["cidr_block"]]
+  cidr_blocks_app        = [local.subnet_configs["private_app"]["eu-west-2a"]["cidr_block"], local.subnet_configs["private_app"]["eu-west-2b"]["cidr_block"]]
   cidr_blocks_db         = [local.subnet_configs["private_db"]["eu-west-2a"]["cidr_block"], local.subnet_configs["private_db"]["eu-west-2b"]["cidr_block"]]
 }


### PR DESCRIPTION
Updated DEV & INT to add extra AZ for app subnet (from Som's spreadsheet) - figured may as well align them now while we are on it.

The CIDR ranges for DEV don't match the spreadsheet (they broadly match an earlier version of the design, where I took the '9' from from App AZ2 - it doesn't conflict with any others I think).
