### PR TITLE
Open SSH port 22 from pub-subs to priv-subs from bastion

### DIFF
--- a/ccs-scale-infra-shared/terraform/modules/bastion/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/bastion/main.tf
@@ -7,6 +7,10 @@ module "globals" {
   source = "../globals"
 }
 
+data "aws_vpc" "scale" {
+  id = var.vpc_id
+}
+
 resource "aws_security_group" "allow_bastion_db_access" {
   name        = "allow_bastion_db_access"
   description = "Allow SSH tunneling to Databases via Bastion host"
@@ -47,6 +51,13 @@ resource "aws_security_group" "allow_bastion_db_access" {
     to_port     = 443
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = [data.aws_vpc.scale.cidr_block]
   }
 }
 

--- a/ccs-scale-infra-shared/terraform/modules/infrastructure/network/vpc.tf
+++ b/ccs-scale-infra-shared/terraform/modules/infrastructure/network/vpc.tf
@@ -277,6 +277,16 @@ resource "aws_network_acl" "scale_external" {
     to_port    = 21976
   }
 
+  # Allow outbound SSH to the VPC
+  egress {
+    protocol   = "tcp"
+    rule_no    = 113
+    action     = "allow"
+    cidr_block = data.aws_vpc.scale.cidr_block
+    from_port  = 22
+    to_port    = 22
+  }
+
   tags = {
     Name        = "SCALE:EU2:${upper(var.environment)}:VPC:ACL-EXTERNAL"
     Project     = module.globals.project_name
@@ -359,6 +369,16 @@ resource "aws_network_acl" "scale_internal" {
     cidr_block = "0.0.0.0/0"
     from_port  = 1024
     to_port    = 65535
+  }
+
+  # Allow inbound traffic on the SSH port from VPC
+  ingress {
+    protocol   = "tcp"
+    rule_no    = 61
+    action     = "allow"
+    cidr_block = data.aws_vpc.scale.cidr_block
+    from_port  = 22
+    to_port    = 22
   }
 
   # Allow outbound VPC traffic on the ephemeral ports for responses to internal services


### PR DESCRIPTION
To enable us to jump/tunnel SSH via bastion to EC2 instances in the private subnets, open:

1. Outbound port 22 at NACL to VPC range from public subnets
2. Outbound port 22 at bastion SG to VPC range
3. Inbound port 22 at NACL from VPC to private subnets