### PR TITLE
Effectively remove CloudFront caching for BaT UIs

### DIFF
--- a/ccs-scale-infra-shared/terraform/modules/infrastructure/cloudfront/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/infrastructure/cloudfront/main.tf
@@ -162,8 +162,8 @@ resource "aws_cloudfront_distribution" "fat_buyer_ui_distribution" {
 
     viewer_protocol_policy = "https-only"
     min_ttl                = 0
-    default_ttl            = 3600
-    max_ttl                = 86400
+    default_ttl            = var.cache_default_ttl
+    max_ttl                = var.cache_max_ttl
   }
 
   restrictions {

--- a/ccs-scale-infra-shared/terraform/modules/infrastructure/cloudfront/variables.tf
+++ b/ccs-scale-infra-shared/terraform/modules/infrastructure/cloudfront/variables.tf
@@ -25,3 +25,11 @@ variable "hosted_zone_name_cdn" {
 variable "resource_label" {
   type = string
 }
+
+variable "cache_default_ttl" {
+  type = number
+}
+
+variable "cache_max_ttl" {
+  type = number
+}

--- a/ccs-scale-infra-shared/terraform/modules/infrastructure/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/infrastructure/main.tf
@@ -63,6 +63,8 @@ module "cloudfront" {
   hosted_zone_name_alb                = data.aws_ssm_parameter.hosted_zone_name_alb.value
   hosted_zone_name_cdn                = data.aws_ssm_parameter.hosted_zone_name_cdn.value
   resource_label                      = "fat-buyer-ui"
+  cache_default_ttl                   = 3600
+  cache_max_ttl                       = 86400
 }
 
 # BaT Buyer UI
@@ -74,6 +76,8 @@ module "cloudfront_bat_client" {
   hosted_zone_name_alb                = data.aws_ssm_parameter.hosted_zone_name_alb_bat_client.value
   hosted_zone_name_cdn                = data.aws_ssm_parameter.hosted_zone_name_cdn_bat_client.value
   resource_label                      = "bat-client"
+  cache_default_ttl                   = 5
+  cache_max_ttl                       = 5
 }
 
 # BaT Spree Backend
@@ -85,4 +89,6 @@ module "cloudfront_bat_backend" {
   hosted_zone_name_alb                = data.aws_ssm_parameter.hosted_zone_name_alb_bat_backend.value
   hosted_zone_name_cdn                = data.aws_ssm_parameter.hosted_zone_name_cdn_bat_backend.value
   resource_label                      = "bat-backend"
+  cache_default_ttl                   = 5
+  cache_max_ttl                       = 5
 }


### PR DESCRIPTION
Thought we should keep the FaT caching as-is. Quick vendor test on SBX1 seemed to work. Figured to split max and default in case we wanted to change independently - but happy to change it in any way.