### PR TITLE
Add env specific Logitio ports in NACLs (SIT,REF,NFT)

### DIFF
--- a/ccs-scale-infra-shared/terraform/environments/int/main.tf
+++ b/ccs-scale-infra-shared/terraform/environments/int/main.tf
@@ -30,4 +30,5 @@ module "deploy" {
   source         = "../../modules/configs/deploy-all"
   aws_account_id = data.aws_ssm_parameter.aws_account_id.value
   environment    = local.environment
+  logitio_port   = 10814
 }

--- a/ccs-scale-infra-shared/terraform/environments/nft/main.tf
+++ b/ccs-scale-infra-shared/terraform/environments/nft/main.tf
@@ -34,4 +34,5 @@ module "deploy" {
   cloudtrail_s3_log_retention_in_days = 2555 #7 years
   cloudwatch_s3_force_destroy         = false
   cloudfront_s3_log_retention_in_days = 2555 #7 years
+  logitio_port                        = 10841
 }

--- a/ccs-scale-infra-shared/terraform/environments/sbx8/main.tf
+++ b/ccs-scale-infra-shared/terraform/environments/sbx8/main.tf
@@ -30,4 +30,5 @@ module "deploy" {
   source         = "../../modules/configs/deploy-all"
   aws_account_id = data.aws_ssm_parameter.aws_account_id.value
   environment    = local.environment
+  logitio_port   = 10868
 }

--- a/ccs-scale-infra-shared/terraform/modules/configs/deploy-all/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/configs/deploy-all/main.tf
@@ -77,6 +77,7 @@ module "infrastructure" {
   public_web_subnet_ids               = split(",", data.aws_ssm_parameter.public_web_subnet_ids.value)
   private_db_subnet_ids               = split(",", data.aws_ssm_parameter.private_db_subnet_ids.value)
   cloudfront_s3_log_retention_in_days = var.cloudfront_s3_log_retention_in_days
+  logitio_port                        = var.logitio_port
 }
 
 module "ssm" {

--- a/ccs-scale-infra-shared/terraform/modules/configs/deploy-all/variables.tf
+++ b/ccs-scale-infra-shared/terraform/modules/configs/deploy-all/variables.tf
@@ -25,3 +25,10 @@ variable "cloudfront_s3_log_retention_in_days" {
   type    = number
   default = 7
 }
+
+variable "logitio_port" {
+  type = number
+
+  # Default logit.io TCP port (use as default for all envs unless overridden)
+  default = 21976
+}

--- a/ccs-scale-infra-shared/terraform/modules/infrastructure/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/infrastructure/main.tf
@@ -52,6 +52,7 @@ module "network" {
   private_db_subnet_ids  = var.private_db_subnet_ids
   nat_eip_ids            = split(",", data.aws_ssm_parameter.nat_eip_ids.value)
   public_nlb_eip_ids     = split(",", data.aws_ssm_parameter.public_nlb_eip_ids.value)
+  logitio_port           = var.logitio_port
 }
 
 # FaT

--- a/ccs-scale-infra-shared/terraform/modules/infrastructure/network/variables.tf
+++ b/ccs-scale-infra-shared/terraform/modules/infrastructure/network/variables.tf
@@ -33,3 +33,7 @@ variable "nat_eip_ids" {
 variable "public_nlb_eip_ids" {
   type = list
 }
+
+variable "logitio_port" {
+  type = number
+}

--- a/ccs-scale-infra-shared/terraform/modules/infrastructure/network/vpc.tf
+++ b/ccs-scale-infra-shared/terraform/modules/infrastructure/network/vpc.tf
@@ -132,8 +132,7 @@ resource "aws_network_acl" "scale_external" {
     to_port    = 65535
   }
 
-  # Allow inbound traffic on ports 587 for sendgrid response
-  # (TODO: Move Spree + Sidekiq ECS services into public subnets to obviate need for this rule)
+  # Allow inbound traffic on ports 587 for sendgrid (from private subnets)
   ingress {
     protocol   = "tcp"
     rule_no    = 31
@@ -143,8 +142,7 @@ resource "aws_network_acl" "scale_external" {
     to_port    = 587
   }
 
-  # Allow inbound traffic on ports 21977 for Logit response
-  # (TODO: Move Spree + Sidekiq ECS services into public subnets to obviate need for this rule)
+  # Allow inbound traffic on ports 21977 for Logit (from private subnets)
   ingress {
     protocol   = "udp"
     rule_no    = 32
@@ -154,8 +152,7 @@ resource "aws_network_acl" "scale_external" {
     to_port    = 21977
   }
 
-  # Allow inbound traffic on ports 21975 for Logit response
-  # (TODO: Move Spree + Sidekiq ECS services into public subnets to obviate need for this rule)
+  # Allow inbound traffic on ports 21975 for Logit (from private subnets)
   ingress {
     protocol   = "tcp"
     rule_no    = 33
@@ -165,8 +162,7 @@ resource "aws_network_acl" "scale_external" {
     to_port    = 21975
   }
 
-  # Allow inbound traffic on ports 21976 for Logit response
-  # (TODO: Move Spree + Sidekiq ECS services into public subnets to obviate need for this rule)
+  # Allow inbound traffic on ports 21976 for Logit (from private subnets)
   ingress {
     protocol   = "tcp"
     rule_no    = 34
@@ -174,6 +170,16 @@ resource "aws_network_acl" "scale_external" {
     cidr_block = data.aws_vpc.scale.cidr_block
     from_port  = 21976
     to_port    = 21976
+  }
+
+  # Allow inbound traffic on environment specific port for Logit.io (from private subnets)
+  ingress {
+    protocol   = "tcp"
+    rule_no    = 35
+    action     = "allow"
+    cidr_block = data.aws_vpc.scale.cidr_block
+    from_port  = var.logitio_port
+    to_port    = var.logitio_port
   }
 
   # Allow all inbound traffic on the SSH port (Bastion host)
@@ -275,6 +281,16 @@ resource "aws_network_acl" "scale_external" {
     cidr_block = "0.0.0.0/0"
     from_port  = 21976
     to_port    = 21976
+  }
+
+  # Allow outbound TCP (Logit.io) traffic on environment specific Logit.io port
+  egress {
+    protocol   = "tcp"
+    rule_no    = 115
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = var.logitio_port
+    to_port    = var.logitio_port
   }
 
   # Allow outbound SSH to the VPC
@@ -402,7 +418,7 @@ resource "aws_network_acl" "scale_internal" {
     to_port    = 65535
   }
 
-  # Allow outbound internet traffic on port 443 (Buyer UI -> NAT / ECR)
+  # Allow outbound internet traffic on port 443 (Spree via NAT -> ECR)
   egress {
     protocol   = "tcp"
     rule_no    = 80
@@ -412,7 +428,7 @@ resource "aws_network_acl" "scale_internal" {
     to_port    = 443
   }
 
-  # Allow outbound internet traffic on port 587 (Spree -> NAT)
+  # Allow outbound TCP (Sendgrid) traffic on port 587 (Spree via NAT)
   egress {
     protocol   = "tcp"
     rule_no    = 90
@@ -422,7 +438,7 @@ resource "aws_network_acl" "scale_internal" {
     to_port    = 587
   }
 
-  # Allow outbound UDP (Logit.io) traffic on port 21977 (Spre -> NAT)
+  # Allow outbound UDP (Logit.io) traffic on port 21977 (Spree via NAT)
   egress {
     protocol   = "udp"
     rule_no    = 100
@@ -432,7 +448,7 @@ resource "aws_network_acl" "scale_internal" {
     to_port    = 21977
   }
 
-  # Allow outbound TCP (Logit.io) traffic on port 21975 (Spre -> NAT)
+  # Allow outbound TCP (Logit.io) traffic on port 21975 (Spree via NAT)
   egress {
     protocol   = "tcp"
     rule_no    = 101
@@ -442,7 +458,7 @@ resource "aws_network_acl" "scale_internal" {
     to_port    = 21975
   }
 
-  # Allow outbound TCP (Logit.io) traffic on port 21976 (Spre -> NAT)
+  # Allow outbound TCP (Logit.io) traffic on port 21976 (Spree via NAT)
   egress {
     protocol   = "tcp"
     rule_no    = 102
@@ -450,6 +466,16 @@ resource "aws_network_acl" "scale_internal" {
     cidr_block = "0.0.0.0/0"
     from_port  = 21976
     to_port    = 21976
+  }
+
+  # Allow outbound TCP (Logit.io) traffic on environment specific port (Spree via NAT)
+  egress {
+    protocol   = "tcp"
+    rule_no    = 103
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = var.logitio_port
+    to_port    = var.logitio_port
   }
 
   tags = {

--- a/ccs-scale-infra-shared/terraform/modules/infrastructure/variables.tf
+++ b/ccs-scale-infra-shared/terraform/modules/infrastructure/variables.tf
@@ -30,3 +30,7 @@ variable "private_db_subnet_ids" {
 variable "cloudfront_s3_log_retention_in_days" {
   type = number
 }
+
+variable "logitio_port" {
+  type = number
+}


### PR DESCRIPTION
Bit of a clumsy "environment specific" Logit.io port for SIT, REF, NFT.  Can't use `count` within NACL inline rules and didn't want to mix it up any further, so have just defaulted to one of the existing ones (21976) - so for SBX+DEV there will just be a duplicate rule - no big deal I hope.