### PR TITLE
Whitelist Referer and User-Agent headers in CF

### DIFF
--- a/ccs-scale-infra-shared/terraform/modules/infrastructure/cloudfront/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/infrastructure/cloudfront/main.tf
@@ -148,7 +148,7 @@ resource "aws_cloudfront_distribution" "fat_buyer_ui_distribution" {
 
     forwarded_values {
       query_string = true
-      headers      = ["Authorization"]
+      headers      = ["Authorization", "Referer", "User-Agent"]
       cookies {
         forward = "all"
       }


### PR DESCRIPTION
Applied to SBX2 and can now see user-agent details of referer and user-agent appearing in BaT client Cloudwatch logs e.g.

```
[2021-02-23T12:38:17.132Z][user: 1][info]: "GET /assets/images/favicon.ico HTTP/1.1" 200 6318 "https://sbx2.marketplace-buyer-ui.scale.crowncommercial.gov.uk/wishlist?_backLink=04d5SB%252FmU31DI%252Ft4mAtsgWqhEkCWGVAzXAqs3xQuXQwA" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.58 Safari/537.36"
```
...where as earlier it was just...
```
[2021-02-23T10:33:17.991Z][user: undefined][info]: "GET /assets/images/favicon.ico HTTP/1.1" 200 6318 "-" "Amazon CloudFront"
```
Hopefully that's it 👍 
