### PR TITLE
Feature/sinf 369 csp header

### DIFF
--- a/ccs-scale-infra-shared/terraform/modules/infrastructure/cloudfront/functions/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/infrastructure/cloudfront/functions/main.tf
@@ -4,6 +4,9 @@
 # 1) Add Security Headers
 #########################################################
 
+locals {
+  function_name = "scale-${var.resource_label}-${lower(var.environment)}-security-headers"
+}
 # Aliased provider for us-east-1 region for use by specific resources (e.g. ACM certificates)
 provider "aws" {
   alias  = "lambda_edge"
@@ -30,6 +33,24 @@ resource "aws_iam_role" "lambda_edge_exec" {
 EOF
 }
 
+data "aws_iam_policy" "ssm_read_only_access" {
+  arn = "arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "ssm_ro_attach" {
+  role       = aws_iam_role.lambda_edge_exec.name
+  policy_arn = data.aws_iam_policy.ssm_read_only_access.arn
+}
+
+data "aws_iam_policy" "lambda_basic_exec" {
+  arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_exec_attach" {
+  role       = aws_iam_role.lambda_edge_exec.name
+  policy_arn = data.aws_iam_policy.lambda_basic_exec.arn
+}
+
 data "archive_file" "lambda_security_headers_zip" {
   type        = "zip"
   source_dir  = "${path.module}/security-headers"
@@ -42,11 +63,19 @@ resource "aws_lambda_function" "security_headers" {
 
   filename         = "${path.module}/.build/security-headers.zip"
   source_code_hash = data.archive_file.lambda_security_headers_zip.output_base64sha256
-  function_name    = "scale-${var.resource_label}-${lower(var.environment)}-security-headers"
+  function_name    = local.function_name
   role             = aws_iam_role.lambda_edge_exec.arn
   description      = "Add HTTP security headers to responses"
   handler          = "index.handler"
   runtime          = "nodejs12.x"
   timeout          = 10
   publish          = true
+}
+
+# BaT Spree Backend
+resource "aws_ssm_parameter" "csp" {
+  name      = "/bat/${local.function_name}-csp"
+  type      = "String"
+  value     = var.content_security_policy
+  overwrite = true
 }

--- a/ccs-scale-infra-shared/terraform/modules/infrastructure/cloudfront/functions/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/infrastructure/cloudfront/functions/main.tf
@@ -72,7 +72,7 @@ resource "aws_lambda_function" "security_headers" {
   publish          = true
 }
 
-# BaT Spree Backend
+# Parameter that will be read by security_headers Lambda@edge function
 resource "aws_ssm_parameter" "csp" {
   name      = "/bat/${local.function_name}-csp"
   type      = "String"

--- a/ccs-scale-infra-shared/terraform/modules/infrastructure/cloudfront/functions/security-headers/index.js
+++ b/ccs-scale-infra-shared/terraform/modules/infrastructure/cloudfront/functions/security-headers/index.js
@@ -74,9 +74,6 @@ exports.handler = async (event, context, callback) => {
     },
   ];
 
-  console.log('Exiting lambda >>');
-  console.log(headers);
-
   //Return modified response
   callback(null, response);
 };

--- a/ccs-scale-infra-shared/terraform/modules/infrastructure/cloudfront/functions/security-headers/index.js
+++ b/ccs-scale-infra-shared/terraform/modules/infrastructure/cloudfront/functions/security-headers/index.js
@@ -5,6 +5,7 @@ AWS.config.update({
 });
 var ssm = new AWS.SSM();
 
+//Local cache of CSP header
 let contentSecurityPolicy;
 
 exports.handler = async (event, context, callback) => {
@@ -12,7 +13,7 @@ exports.handler = async (event, context, callback) => {
   const response = event.Records[0].cf.response;
   const headers = response.headers;
 
-  // functionName will be 'eu-east-1.scale-bat-backend-sbx1-security-headers'
+  //Need to strip 'eu-east-1' prefix from function name
   const functionName = context.functionName.split('.').pop();
   
   async function getSSMParameter(paramName){
@@ -26,6 +27,7 @@ exports.handler = async (event, context, callback) => {
   
   async function setContentSecurityPolicy(headers){
     if(contentSecurityPolicy == undefined){
+      // Parameter name is based on function name and are auto created in Terraform, so should always align
       const cspHeaderParamName = '/bat/' + functionName + '-csp';
       contentSecurityPolicy = await getSSMParameter(cspHeaderParamName);
     } 

--- a/ccs-scale-infra-shared/terraform/modules/infrastructure/cloudfront/functions/variables.tf
+++ b/ccs-scale-infra-shared/terraform/modules/infrastructure/cloudfront/functions/variables.tf
@@ -14,3 +14,7 @@ variable "environment" {
 variable "resource_label" {
   type = string
 }
+
+variable "content_security_policy" {
+  type = string
+}

--- a/ccs-scale-infra-shared/terraform/modules/infrastructure/cloudfront/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/infrastructure/cloudfront/main.tf
@@ -97,10 +97,11 @@ data "aws_acm_certificate" "cdn" {
 # Lambda@Edge functions
 ##############################################################
 module "functions" {
-  source         = "./functions"
-  aws_account_id = var.aws_account_id
-  environment    = var.environment
-  resource_label = var.resource_label
+  source                  = "./functions"
+  aws_account_id          = var.aws_account_id
+  environment             = var.environment
+  resource_label          = var.resource_label
+  content_security_policy = var.content_security_policy
 }
 
 ##############################################################

--- a/ccs-scale-infra-shared/terraform/modules/infrastructure/cloudfront/variables.tf
+++ b/ccs-scale-infra-shared/terraform/modules/infrastructure/cloudfront/variables.tf
@@ -33,3 +33,7 @@ variable "cache_default_ttl" {
 variable "cache_max_ttl" {
   type = number
 }
+
+variable "content_security_policy" {
+  type = string
+}

--- a/ccs-scale-infra-shared/terraform/modules/infrastructure/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/infrastructure/main.tf
@@ -95,7 +95,7 @@ module "cloudfront_bat_backend" {
   cache_default_ttl                   = 0
   cache_max_ttl                       = 0
   // Image source requires CCS and S3 domains as BaT product images are loaded via a redirect to an S3 pre-signed URL
-  content_security_policy             = "default-src 'none'; img-src 'self' *.crowncommercial.gov.uk *.s3.eu-west-2.amazonaws.com data:; script-src 'self' 'unsafe-inline' js-agent.newrelic.com bam.eu01.nr-data.net; font-src 'self' fonts.gstatic.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com; object-src 'unsafe-inline'"
+  content_security_policy             = "default-src 'none'; img-src 'self' *.crowncommercial.gov.uk *.s3.eu-west-2.amazonaws.com data:; script-src 'self' 'unsafe-inline' js-agent.newrelic.com bam.eu01.nr-data.net; font-src 'self' fonts.gstatic.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com; object-src 'unsafe-inline'; connect-src bam.eu01.nr-data.net"
 
 }
 

--- a/ccs-scale-infra-shared/terraform/modules/infrastructure/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/infrastructure/main.tf
@@ -66,7 +66,8 @@ module "cloudfront" {
   resource_label                      = "fat-buyer-ui"
   cache_default_ttl                   = 3600
   cache_max_ttl                       = 86400
-}
+  content_security_policy             = "default-src 'none'; img-src 'self'; script-src 'self' 'unsafe-inline'; font-src fonts.gstatic.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com; object-src 'none'"
+  }
 
 # BaT Buyer UI
 module "cloudfront_bat_client" {
@@ -79,9 +80,10 @@ module "cloudfront_bat_client" {
   resource_label                      = "bat-client"
   cache_default_ttl                   = 0
   cache_max_ttl                       = 0
+  // Image source requires CCS and S3 domains as BaT product images are loaded via a redirect to an S3 pre-signed URL
+  content_security_policy             = "default-src 'none'; img-src 'self' *.crowncommercial.gov.uk *.s3.eu-west-2.amazonaws.com; script-src 'self' 'unsafe-inline'; font-src fonts.gstatic.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com; object-src 'none'"
 }
 
-# BaT Spree Backend
 module "cloudfront_bat_backend" {
   source                              = "./cloudfront"
   aws_account_id                      = var.aws_account_id
@@ -92,4 +94,9 @@ module "cloudfront_bat_backend" {
   resource_label                      = "bat-backend"
   cache_default_ttl                   = 0
   cache_max_ttl                       = 0
+  // Image source requires CCS and S3 domains as BaT product images are loaded via a redirect to an S3 pre-signed URL
+  content_security_policy             = "default-src 'none'; img-src 'self' *.crowncommercial.gov.uk *.s3.eu-west-2.amazonaws.com data:; script-src 'self' 'unsafe-inline' js-agent.newrelic.com bam.eu01.nr-data.net; font-src 'self' fonts.gstatic.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com; object-src 'unsafe-inline'"
+
 }
+
+


### PR DESCRIPTION
Updated security_headers Lambda function to support instance specific content-security-policy header - key changes:

1) Uses SSM params to store and red content-security-policy (uses function name in the param name to infer it - as cannot pass vars into lambda@edge functions - afaik) (if we could do that we would not need to use SSM at all)

2) Main change to content-security-policy is in the admin interface. To replicate - view the current UI on dev with Chrome dev tools open - can see the problems in red. This should resolve them

3) Happy top change any/all - just best guess with NodeJS approach