### PR TITLE
Specify SSM CMK for secure param

### DIFF
--- a/ccs-scale-infra-shared/terraform/modules/infrastructure/cloudfront/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/infrastructure/cloudfront/main.tf
@@ -20,6 +20,10 @@ provider "aws" {
   }
 }
 
+data "aws_ssm_parameter" "kms_id_ssm" {
+  name = "${lower(var.environment)}-ssm-encryption-key"
+}
+
 resource "random_password" "cloudfront_id" {
   length  = 16
   special = false
@@ -31,6 +35,7 @@ resource "aws_ssm_parameter" "cloudfront_id" {
   type      = "SecureString"
   value     = random_password.cloudfront_id.result
   overwrite = true
+  key_id    = data.aws_ssm_parameter.kms_id_ssm.value
 }
 
 resource "aws_s3_bucket" "logs" {


### PR DESCRIPTION
Working through the repos applying this change wherever an SSM parameter is _created_ as `type = "SecureString"`.  Should be a null change as the [script](https://github.com/Crown-Commercial-Service/ccs-scale-bootstrap/pull/118/files#diff-4992b630ca3a501f6755d4c310e4ca272602b119b74f4357f0d95ce8ac512c9c) will have already been run to update them all.