### PR TITLE
Provision Kali instance for pen test

### DIFF
--- a/ccs-scale-infra-shared/terraform/environments/nft/main.tf
+++ b/ccs-scale-infra-shared/terraform/environments/nft/main.tf
@@ -35,4 +35,6 @@ module "deploy" {
   cloudwatch_s3_force_destroy         = false
   cloudfront_s3_log_retention_in_days = 2555 #7 years
   logitio_port                        = 10841
+  kali_instance                       = true
+  kali_instance_type                  = "t2.xlarge"
 }

--- a/ccs-scale-infra-shared/terraform/modules/bastion/kali.tf
+++ b/ccs-scale-infra-shared/terraform/modules/bastion/kali.tf
@@ -1,0 +1,24 @@
+resource "aws_instance" "kali" {
+  count = var.kali_instance ? 1 : 0
+
+  ami                         = "ami-0794045bcaf370ece"
+  instance_type               = var.kali_instance_type
+  key_name                    = "${lower(var.environment)}-kali-key"
+  subnet_id                   = var.subnet_id
+  vpc_security_group_ids      = [aws_security_group.allow_bastion_db_access.id]
+  associate_public_ip_address = true
+
+  root_block_device {
+    encrypted   = true
+    kms_key_id  = var.bastion_kms_key_id
+    volume_size = 70
+  }
+
+  tags = {
+    Name        = "SCALE-EU2-${upper(var.environment)}-EC2-KALI-PEN-TEST"
+    Project     = module.globals.project_name
+    Environment = upper(var.environment)
+    Cost_Code   = module.globals.project_cost_code
+    AppType     = "EC2"
+  }
+}

--- a/ccs-scale-infra-shared/terraform/modules/bastion/variables.tf
+++ b/ccs-scale-infra-shared/terraform/modules/bastion/variables.tf
@@ -21,3 +21,11 @@ variable "bastion_kms_key_id" {
 variable "cidr_blocks_allowed_external" {
   type = list
 }
+
+variable "kali_instance" {
+  type = bool
+}
+
+variable "kali_instance_type" {
+  type = string
+}

--- a/ccs-scale-infra-shared/terraform/modules/configs/deploy-all/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/configs/deploy-all/main.tf
@@ -99,6 +99,8 @@ module "bastion" {
   db_cidr_blocks               = split(",", data.aws_ssm_parameter.cidr_blocks_db.value)
   bastion_kms_key_id           = data.aws_ssm_parameter.bastion_kms_key_id.value
   cidr_blocks_allowed_external = concat(local.cidr_blocks_allowed_external_ccs, local.cidr_blocks_allowed_external_spark, local.cidr_blocks_allowed_external_cognizant)
+  kali_instance                = var.kali_instance
+  kali_instance_type           = var.kali_instance_type
 }
 
 # CloudTrail is not really required in lower enviromnments.

--- a/ccs-scale-infra-shared/terraform/modules/configs/deploy-all/variables.tf
+++ b/ccs-scale-infra-shared/terraform/modules/configs/deploy-all/variables.tf
@@ -32,3 +32,13 @@ variable "logitio_port" {
   # Default logit.io TCP port (use as default for all envs unless overridden)
   default = 21976
 }
+
+variable "kali_instance" {
+  type    = bool
+  default = false
+}
+
+variable "kali_instance_type" {
+  type    = string
+  default = "t2.micro"
+}

--- a/ccs-scale-infra-shared/terraform/modules/infrastructure/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/infrastructure/main.tf
@@ -68,7 +68,7 @@ module "cloudfront" {
   cache_max_ttl                       = 86400
   content_security_policy             = "default-src 'none'; img-src 'self'; script-src 'self' 'unsafe-inline'; font-src fonts.gstatic.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com; object-src 'none'"
   forwarded_headers                   = ["Authorization", "Referer", "User-Agent"]
-  }
+}
 
 # BaT Buyer UI
 module "cloudfront_bat_client" {
@@ -82,8 +82,8 @@ module "cloudfront_bat_client" {
   cache_default_ttl                   = 0
   cache_max_ttl                       = 0
   // Image source requires CCS and S3 domains as BaT product images are loaded via a redirect to an S3 pre-signed URL
-  content_security_policy             = "default-src 'none'; img-src 'self' *.crowncommercial.gov.uk *.s3.eu-west-2.amazonaws.com; script-src 'self' 'unsafe-inline'; font-src fonts.gstatic.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com; object-src 'none'"
-  forwarded_headers                   = ["Authorization", "Referer", "User-Agent"]
+  content_security_policy = "default-src 'none'; img-src 'self' *.crowncommercial.gov.uk *.s3.eu-west-2.amazonaws.com; script-src 'self' 'unsafe-inline'; font-src fonts.gstatic.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com; object-src 'none'"
+  forwarded_headers       = ["Authorization", "Referer", "User-Agent"]
 }
 
 module "cloudfront_bat_backend" {
@@ -97,8 +97,8 @@ module "cloudfront_bat_backend" {
   cache_default_ttl                   = 0
   cache_max_ttl                       = 0
   // Image source requires CCS and S3 domains as BaT product images are loaded via a redirect to an S3 pre-signed URL
-  content_security_policy             = "default-src 'none'; img-src 'self' *.crowncommercial.gov.uk *.s3.eu-west-2.amazonaws.com data:; script-src 'self' 'unsafe-inline' js-agent.newrelic.com bam.eu01.nr-data.net; font-src 'self' fonts.gstatic.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com; object-src 'unsafe-inline'; connect-src 'self' bam.eu01.nr-data.net"
-  forwarded_headers                   = ["Authorization", "Referer", "User-Agent", "Accept"]
+  content_security_policy = "default-src 'none'; img-src 'self' *.crowncommercial.gov.uk *.s3.eu-west-2.amazonaws.com data:; script-src 'self' 'unsafe-inline' js-agent.newrelic.com bam.eu01.nr-data.net; font-src 'self' fonts.gstatic.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com; object-src 'unsafe-inline'; connect-src 'self' bam.eu01.nr-data.net"
+  forwarded_headers       = ["Authorization", "Referer", "User-Agent", "Accept"]
 
 }
 


### PR DESCRIPTION
Tried and tested in SBX2 - this should provision Kali in NFT only.  Removed the user data as the upgrade command required manual intervention and EC2 instance connect is not available anyway.