### PR TITLE
SCA-3154 - enable cross zone load balancing

### DIFF
--- a/ccs-scale-infra-shared/terraform/modules/infrastructure/network/load-balancer.tf
+++ b/ccs-scale-infra-shared/terraform/modules/infrastructure/network/load-balancer.tf
@@ -39,6 +39,7 @@ resource "aws_lb" "private" {
   internal           = true
   load_balancer_type = "network"
   subnets            = var.private_app_subnet_ids
+  enable_cross_zone_load_balancing = true
 
   tags = {
     Project     = module.globals.project_name
@@ -53,6 +54,7 @@ resource "aws_lb" "private_db" {
   internal           = true
   load_balancer_type = "network"
   subnets            = var.private_db_subnet_ids
+  enable_cross_zone_load_balancing = true
 
   tags = {
     Project     = module.globals.project_name


### PR DESCRIPTION
This is to hopefully address an issue raised during OAT where terminating 2 of the 3 Spree EC2 instances caused longer outage and errors in client than expected.

I think this due to cross zone load balancing on internal app NLB being disabled (the default setting) - so any requests to clients in AZs where the Spree instances had been terminated would fail (as it would not route to another AZ).

Also update the DB NLB, as potentially the same may occur there.