### PR TITLE
Feature/sinf 438 encrypt cloudtrail

### DIFF
--- a/.github/workflows/tfsec-analysis.yml
+++ b/.github/workflows/tfsec-analysis.yml
@@ -9,7 +9,7 @@ on:
   push:
     branches: [ develop, bat/develop, master ]
   pull_request:
-    branches: [ develop ]  
+    branches: [ develop, bat/develop ]  
   schedule:
     - cron: '43 3 * * 5'
 

--- a/ccs-scale-infra-shared/terraform/modules/cloudtrail/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/cloudtrail/main.tf
@@ -12,10 +12,6 @@ module "globals" {
   source = "../globals"
 }
 
-data "aws_caller_identity" "current" {}
-
-
-
 ##########################
 # CloudTrail log bucket
 ##########################
@@ -99,7 +95,7 @@ POLICY
 resource "aws_cloudwatch_log_group" "cloudtrail" {
   name              = "/cloudtrail/${lower(var.environment)}"
   retention_in_days = var.cloudtrail_cw_log_retention_in_days
-  kms_key_id        = aws_kms_key.cloudtrail.arn
+  kms_key_id        = var.cloudtrail_kms_key_arn
 
   tags = {
     Project     = module.globals.project_name

--- a/ccs-scale-infra-shared/terraform/modules/cloudtrail/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/cloudtrail/main.tf
@@ -95,7 +95,7 @@ POLICY
 resource "aws_cloudwatch_log_group" "cloudtrail" {
   name              = "/cloudtrail/${lower(var.environment)}"
   retention_in_days = var.cloudtrail_cw_log_retention_in_days
-  kms_key_id        = var.cloudtrail_kms_key_arn
+  kms_key_id        = var.cloudwatch_kms_key_arn
 
   tags = {
     Project     = module.globals.project_name

--- a/ccs-scale-infra-shared/terraform/modules/cloudtrail/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/cloudtrail/main.tf
@@ -95,7 +95,7 @@ POLICY
 resource "aws_cloudwatch_log_group" "cloudtrail" {
   name              = "/cloudtrail/${lower(var.environment)}"
   retention_in_days = var.cloudtrail_cw_log_retention_in_days
-  kms_key_id        = var.cloudtrail_kms_key_arn
+  #ms_key_id        = var.cloudtrail_kms_key_arn
 
   tags = {
     Project     = module.globals.project_name

--- a/ccs-scale-infra-shared/terraform/modules/cloudtrail/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/cloudtrail/main.tf
@@ -95,7 +95,7 @@ POLICY
 resource "aws_cloudwatch_log_group" "cloudtrail" {
   name              = "/cloudtrail/${lower(var.environment)}"
   retention_in_days = var.cloudtrail_cw_log_retention_in_days
-  #ms_key_id        = var.cloudtrail_kms_key_arn
+  kms_key_id        = var.cloudtrail_kms_key_arn
 
   tags = {
     Project     = module.globals.project_name

--- a/ccs-scale-infra-shared/terraform/modules/cloudtrail/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/cloudtrail/main.tf
@@ -14,77 +14,7 @@ module "globals" {
 
 data "aws_caller_identity" "current" {}
 
-##########################
-# KMS Key
-##########################
-resource "aws_kms_key" "cloudtrail" {
-  description         = "CloudTrail Logs Key"
-  enable_key_rotation = true
 
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "Enable IAM User Permissions",
-      "Effect": "Allow",
-      "Principal": {
-          "AWS": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
-      },
-      "Action": "kms:*",
-      "Resource": "*"
-    },
-    {
-      "Sid": "Allow CloudTrail to encrypt logs",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "cloudtrail.amazonaws.com"
-      },
-      "Action": "kms:GenerateDataKey*",
-      "Resource": "*",
-      "Condition": {
-        "StringLike": {
-          "kms:EncryptionContext:aws:cloudtrail:arn": [
-            "arn:aws:cloudtrail:*:${data.aws_caller_identity.current.account_id}:trail/*"
-          ]
-        }
-      }
-    },
-    {
-      "Effect": "Allow",
-      "Principal": {
-          "Service": "logs.eu-west-2.amazonaws.com"
-      },
-      "Action": [
-          "kms:Encrypt*",
-          "kms:Decrypt*",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:Describe*"
-      ],
-      "Resource": "*",
-      "Condition": {
-          "ArnEquals": {
-              "kms:EncryptionContext:aws:logs:arn": "arn:aws:logs:*:${data.aws_caller_identity.current.account_id}:*"
-          }
-      }
-    }  
-  ]
-}
-EOF
-
-  tags = {
-    Project     = module.globals.project_name
-    Environment = upper(var.environment)
-    Cost_Code   = module.globals.project_cost_code
-    AppType     = "CLOUDTRAIL"
-  }
-}
-
-resource "aws_kms_alias" "cloudtrail" {
-  name          = "alias/cloudtrail"
-  target_key_id = aws_kms_key.cloudtrail.key_id
-}
 
 ##########################
 # CloudTrail log bucket
@@ -240,7 +170,7 @@ resource "aws_cloudtrail" "scale" {
   enable_log_file_validation    = true
   cloud_watch_logs_group_arn    = aws_cloudwatch_log_group.cloudtrail.arn
   cloud_watch_logs_role_arn     = aws_iam_role.cloudtrail.arn
-  kms_key_id                    = aws_kms_key.cloudtrail.arn
+  kms_key_id                    = var.cloudtrail_kms_key_arn
   is_multi_region_trail         = true
 }
 

--- a/ccs-scale-infra-shared/terraform/modules/cloudtrail/variables.tf
+++ b/ccs-scale-infra-shared/terraform/modules/cloudtrail/variables.tf
@@ -21,3 +21,7 @@ variable "cloudwatch_s3_force_destroy" {
 variable "cloudtrail_kms_key_arn" {
   type = string
 }
+
+variable "cloudwatch_kms_key_arn" {
+  type = string
+}

--- a/ccs-scale-infra-shared/terraform/modules/cloudtrail/variables.tf
+++ b/ccs-scale-infra-shared/terraform/modules/cloudtrail/variables.tf
@@ -17,3 +17,7 @@ variable "cloudtrail_s3_log_retention_in_days" {
 variable "cloudwatch_s3_force_destroy" {
   type = bool
 }
+
+variable "cloudtrail_kms_key_arn" {
+  type = string
+}

--- a/ccs-scale-infra-shared/terraform/modules/configs/deploy-all/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/configs/deploy-all/main.tf
@@ -68,6 +68,10 @@ locals {
   cidr_blocks_allowed_external_cognizant = data.aws_ssm_parameter.cidr_blocks_allowed_external_cognizant.value != "-" ? split(",", data.aws_ssm_parameter.cidr_blocks_allowed_external_cognizant.value) : []
 }
 
+module "kms" {
+  source = "../../kms"
+}
+
 module "infrastructure" {
   source                              = "../../infrastructure"
   aws_account_id                      = var.aws_account_id
@@ -81,14 +85,15 @@ module "infrastructure" {
 }
 
 module "ssm" {
-  source            = "../../ssm"
-  environment       = var.environment
-  lb_private_arn    = module.infrastructure.lb_private_arn
-  lb_private_db_arn = module.infrastructure.lb_private_db_arn
-  lb_public_alb_arn = module.infrastructure.lb_public_alb_arn
-  vpc_link_id       = module.infrastructure.vpc_link_id
-  lb_private_dns    = module.infrastructure.lb_private_dns
-  lb_private_db_dns = module.infrastructure.lb_private_db_dns
+  source                 = "../../ssm"
+  environment            = var.environment
+  lb_private_arn         = module.infrastructure.lb_private_arn
+  lb_private_db_arn      = module.infrastructure.lb_private_db_arn
+  lb_public_alb_arn      = module.infrastructure.lb_public_alb_arn
+  vpc_link_id            = module.infrastructure.vpc_link_id
+  lb_private_dns         = module.infrastructure.lb_private_dns
+  lb_private_db_dns      = module.infrastructure.lb_private_db_dns
+  cloudwatch_kms_key_arn = module.kms.cloudwatch_kms_key_arn
 }
 
 module "bastion" {
@@ -114,4 +119,5 @@ module "cloudtrail" {
   cloudtrail_cw_log_retention_in_days = var.cloudtrail_cw_log_retention_in_days
   cloudtrail_s3_log_retention_in_days = var.cloudtrail_s3_log_retention_in_days
   cloudwatch_s3_force_destroy         = var.cloudwatch_s3_force_destroy
+  cloudtrail_kms_key_arn              = module.kms.cloudtrail_kms_key_arn
 }

--- a/ccs-scale-infra-shared/terraform/modules/configs/deploy-all/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/configs/deploy-all/main.tf
@@ -122,4 +122,5 @@ module "cloudtrail" {
   cloudtrail_s3_log_retention_in_days = var.cloudtrail_s3_log_retention_in_days
   cloudwatch_s3_force_destroy         = var.cloudwatch_s3_force_destroy
   cloudtrail_kms_key_arn              = module.kms.cloudtrail_kms_key_arn
+  cloudwatch_kms_key_arn              = module.kms.cloudwatch_kms_key_arn
 }

--- a/ccs-scale-infra-shared/terraform/modules/configs/deploy-all/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/configs/deploy-all/main.tf
@@ -70,6 +70,8 @@ locals {
 
 module "kms" {
   source = "../../kms"
+  aws_account_id                      = var.aws_account_id
+  environment                         = var.environment
 }
 
 module "infrastructure" {

--- a/ccs-scale-infra-shared/terraform/modules/kms/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/kms/main.tf
@@ -44,26 +44,6 @@ resource "aws_kms_key" "cloudtrail" {
           ]
         }
       }
-    },
-    {
-      "Sid": "Allow CloudWatch permission to use key",
-      "Effect": "Allow",
-      "Principal": {
-          "Service": "logs.eu-west-2.amazonaws.com"
-      },
-      "Action": [
-          "kms:Encrypt*",
-          "kms:Decrypt*",
-          "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
-          "kms:Describe*"
-      ],
-      "Resource": "*",
-      "Condition": {
-          "ArnEquals": {
-              "kms:EncryptionContext:aws:logs:arn": "arn:aws:logs:*:${var.aws_account_id}:*"
-          }
-      }
     }
   ]
 }
@@ -81,7 +61,6 @@ resource "aws_kms_alias" "cloudtrail" {
   name          = "alias/cloudtrail"
   target_key_id = aws_kms_key.cloudtrail.key_id
 }
-
 
 ##########################
 # CloudWatch KMS Key

--- a/ccs-scale-infra-shared/terraform/modules/kms/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/kms/main.tf
@@ -85,6 +85,9 @@ resource "aws_kms_alias" "cloudtrail" {
 
 ##########################
 # CloudWatch KMS Key
+# 
+# Can be used for CW logs
+# across other repos
 ##########################
 resource "aws_kms_key" "cloudwatch" {
   description         = "CloudWatch Logs Key"

--- a/ccs-scale-infra-shared/terraform/modules/kms/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/kms/main.tf
@@ -1,3 +1,14 @@
+
+#########################################################
+# KMS
+#
+# Customer Manager KMS Keys
+#########################################################
+
+module "globals" {
+  source = "../globals"
+}
+
 ##########################
 # CloudTrail KMS Key
 ##########################
@@ -13,7 +24,7 @@ resource "aws_kms_key" "cloudtrail" {
       "Sid": "Enable IAM User Permissions",
       "Effect": "Allow",
       "Principal": {
-          "AWS": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+          "AWS": "arn:aws:iam::${var.aws_account_id}:root"
       },
       "Action": "kms:*",
       "Resource": "*"
@@ -29,9 +40,29 @@ resource "aws_kms_key" "cloudtrail" {
       "Condition": {
         "StringLike": {
           "kms:EncryptionContext:aws:cloudtrail:arn": [
-            "arn:aws:cloudtrail:*:${data.aws_caller_identity.current.account_id}:trail/*"
+            "arn:aws:cloudtrail:*:${var.aws_account_id}:trail/*"
           ]
         }
+      }
+    },
+    {
+      "Sid": "Allow CloudWatch permission to use key",
+      "Effect": "Allow",
+      "Principal": {
+          "Service": "logs.eu-west-2.amazonaws.com"
+      },
+      "Action": [
+          "kms:Encrypt*",
+          "kms:Decrypt*",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:Describe*"
+      ],
+      "Resource": "*",
+      "Condition": {
+          "ArnEquals": {
+              "kms:EncryptionContext:aws:logs:arn": "arn:aws:logs:*:${var.aws_account_id}:*"
+          }
       }
     }
   ]
@@ -67,7 +98,7 @@ resource "aws_kms_key" "cloudwatch" {
       "Sid": "Enable IAM User Permissions",
       "Effect": "Allow",
       "Principal": {
-          "AWS": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+          "AWS": "arn:aws:iam::${var.aws_account_id}:root"
       },
       "Action": "kms:*",
       "Resource": "*"
@@ -88,7 +119,7 @@ resource "aws_kms_key" "cloudwatch" {
       "Resource": "*",
       "Condition": {
           "ArnEquals": {
-              "kms:EncryptionContext:aws:logs:arn": "arn:aws:logs:*:${data.aws_caller_identity.current.account_id}:*"
+              "kms:EncryptionContext:aws:logs:arn": "arn:aws:logs:*:${var.aws_account_id}:*"
           }
       }
     }  

--- a/ccs-scale-infra-shared/terraform/modules/kms/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/kms/main.tf
@@ -1,0 +1,110 @@
+##########################
+# CloudTrail KMS Key
+##########################
+resource "aws_kms_key" "cloudtrail" {
+  description         = "CloudTrail Logs Key"
+  enable_key_rotation = true
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Enable IAM User Permissions",
+      "Effect": "Allow",
+      "Principal": {
+          "AWS": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+      },
+      "Action": "kms:*",
+      "Resource": "*"
+    },
+    {
+      "Sid": "Allow CloudTrail to encrypt logs",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "cloudtrail.amazonaws.com"
+      },
+      "Action": "kms:GenerateDataKey*",
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "kms:EncryptionContext:aws:cloudtrail:arn": [
+            "arn:aws:cloudtrail:*:${data.aws_caller_identity.current.account_id}:trail/*"
+          ]
+        }
+      }
+    }
+  ]
+}
+EOF
+
+  tags = {
+    Project     = module.globals.project_name
+    Environment = upper(var.environment)
+    Cost_Code   = module.globals.project_cost_code
+    AppType     = "KMS"
+  }
+}
+
+resource "aws_kms_alias" "cloudtrail" {
+  name          = "alias/cloudtrail"
+  target_key_id = aws_kms_key.cloudtrail.key_id
+}
+
+
+##########################
+# CloudWatch KMS Key
+##########################
+resource "aws_kms_key" "cloudwatch" {
+  description         = "CloudWatch Logs Key"
+  enable_key_rotation = true
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Enable IAM User Permissions",
+      "Effect": "Allow",
+      "Principal": {
+          "AWS": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+      },
+      "Action": "kms:*",
+      "Resource": "*"
+    },
+    {
+      "Sid": "Allow CloudWatch permission to use key",
+      "Effect": "Allow",
+      "Principal": {
+          "Service": "logs.eu-west-2.amazonaws.com"
+      },
+      "Action": [
+          "kms:Encrypt*",
+          "kms:Decrypt*",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:Describe*"
+      ],
+      "Resource": "*",
+      "Condition": {
+          "ArnEquals": {
+              "kms:EncryptionContext:aws:logs:arn": "arn:aws:logs:*:${data.aws_caller_identity.current.account_id}:*"
+          }
+      }
+    }  
+  ]
+}
+EOF
+
+  tags = {
+    Project     = module.globals.project_name
+    Environment = upper(var.environment)
+    Cost_Code   = module.globals.project_cost_code
+    AppType     = "KMS"
+  }
+}
+
+resource "aws_kms_alias" "cloudwatch" {
+  name          = "alias/cloudwatch"
+  target_key_id = aws_kms_key.cloudwatch.key_id
+}

--- a/ccs-scale-infra-shared/terraform/modules/kms/outputs.tf
+++ b/ccs-scale-infra-shared/terraform/modules/kms/outputs.tf
@@ -1,0 +1,11 @@
+/*
+ * KMS outputs
+ */
+output "cloudtrail_kms_key_arn" {
+  value = aws_kms_key.cloudtrail.arn
+}
+
+output "cloudwatch_kms_key_arn" {
+  value = aws_kms_key.cloudwatch.arn
+}
+

--- a/ccs-scale-infra-shared/terraform/modules/kms/outputs.tf
+++ b/ccs-scale-infra-shared/terraform/modules/kms/outputs.tf
@@ -1,6 +1,3 @@
-/*
- * KMS outputs
- */
 output "cloudtrail_kms_key_arn" {
   value = aws_kms_key.cloudtrail.arn
 }
@@ -8,4 +5,3 @@ output "cloudtrail_kms_key_arn" {
 output "cloudwatch_kms_key_arn" {
   value = aws_kms_key.cloudwatch.arn
 }
-

--- a/ccs-scale-infra-shared/terraform/modules/kms/variables.tf
+++ b/ccs-scale-infra-shared/terraform/modules/kms/variables.tf
@@ -1,0 +1,7 @@
+variable "environment" {
+  type = string
+}
+
+variable "aws_account_id" {
+  type = string
+}

--- a/ccs-scale-infra-shared/terraform/modules/ssm/main.tf
+++ b/ccs-scale-infra-shared/terraform/modules/ssm/main.tf
@@ -45,3 +45,10 @@ resource "aws_ssm_parameter" "lb_private_db_dns" {
   value     = var.lb_private_db_dns
   overwrite = true
 }
+
+resource "aws_ssm_parameter" "cloudwatch_kms_key_arn" {
+  name      = "${lower(var.environment)}-cloudwatch-kms-key-arn"
+  type      = "String"
+  value     = var.cloudwatch_kms_key_arn
+  overwrite = true
+}

--- a/ccs-scale-infra-shared/terraform/modules/ssm/variables.tf
+++ b/ccs-scale-infra-shared/terraform/modules/ssm/variables.tf
@@ -25,3 +25,7 @@ variable "lb_private_dns" {
 variable "lb_private_db_dns" {
   type = string
 }
+
+variable "cloudwatch_kms_key_arn" {
+  type = string
+}


### PR DESCRIPTION
This should fix 3 issues related to CloudTrail identified in the code scans (see the checks link below to view fixed issues): 

1. Cloudtrail should be encrypted at rest to secure access to sensitive trail data
2. Cloudtrail should be enabled in all regions regardless of where your AWS resources are generally homed
3. CloudWatch log groups should be encrypted using CMK

Put the KMS keys in their own module - as one of them is output as an SSM parameter and can be referenced in other repos to encrypt CW log groups (and fix the same code scan issues there) - so seemed sensible to split that one out somehow - new module seemed the logical place (and if doing that, then may as well group the CloudTrail specific key there as well).

Very happy to tweak further if you can suggest any improvements!
